### PR TITLE
Add package install commands for Linux Distros and OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,18 @@ sudo yum install openssl libcurl libxml2 pinentry xclip
 
 
 ##### Debian/Ubuntu
-* Install the needed dependencies
+* Debian: Install the needed dependencies
 
 ```
-sudo apt-get install openssl libcurl3 libxml2 pinentry-curses xclip
+sudo apt-get install openssl libcurl3 libxml2 libssl-dev libxml2-dev libcurl4-openssl-dev pinentry-curses xclip
 ```
+
+* Ubuntu: Install the needed dependencies
+
+```
+sudo apt-get install openssl libcurl3 libxml2 libssl-dev libxml2-dev pinentry-curses xclip
+```
+
 
 ##### Other Linux Distros
 Install the packages listed in the Dependencies section of this document.


### PR DESCRIPTION
I've documented how to install the needed packages for Redhat/Centos, Debian/Ubuntu and OS X. 

I don't have linux desktops where I can test the Xclip functionality, but this does cover installing the packages, presumable it'll "just work".
