### PR TITLE
Remove my association from project

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,3 @@ AsciiDoc as a prerequisite.
 Once installed,
 
     $ man lpass
-
-##### Credits
-Author: Jason A. Donenfeld <jasond@lastpass.com>

--- a/contrib/examples/msmtprc
+++ b/contrib/examples/msmtprc
@@ -7,7 +7,7 @@ auth on
 user someuser
 passwordeval lpass Email/companysmtp/someuser
 tls on
-tls_fingerprint 4B:1C:34:EB:19:E9:0F:9C:CB:73:FD:64:60:BA:2F:A8:67:63:1E:05
+tls_fingerprint SOME_TLS_FINGERPRINT
 tls_certcheck on
 
 from someuser@example.com

--- a/lpass.1.txt
+++ b/lpass.1.txt
@@ -140,8 +140,3 @@ in the section above:
 * 'LPASS_AGENT_TIMEOUT'
 * 'LPASS_AGENT_DISABLE'
 * 'LPASS_DISABLE_PINENTRY'
-
-AUTHOR
--------
-*lpass* was written by Jason A. Donenfeld <jasond@lastpass.com>.
-


### PR DESCRIPTION
Though I authored the initial internal versions of this
(client-side) code, I've been told by many that I should be careful
of where I allow my name, because, as a security professional, the
link with it could possibly have some undefined potential to be not
nice for reputation. I thus take the advice of my peers and remove
my name from this codebase.

Signed-off-by: Jason A. Donenfeld Jason@zx2c4.com
