### PR TITLE
Add clipboard support on Cygwin with putclip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 *.d
 lpass
 lpass.1
+lpass.exe
 certificate.h

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ C99 command line interface to [LastPass.com](https://lastpass.com/).
 * [libxml2](http://xmlsoft.org/)
 * [pinentry](https://www.gnupg.org/related_software/pinentry/index.en.html) (optional)
 * [AsciiDoc](http://www.methods.co.nz/asciidoc/) (build-time documentation generation only)
-* [xclip](http://sourceforge.net/projects/xclip/), [xsel](http://www.vergenet.net/~conrad/software/xsel/), or [pbcopy](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/pbcopy.1.html) for clipboard support (optional)
+* [xclip](http://sourceforge.net/projects/xclip/), [xsel](http://www.vergenet.net/~conrad/software/xsel/), [pbcopy](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/pbcopy.1.html), or [putclip from cygutils-extra](https://cygwin.com/cgi-bin2/package-grep.cgi?grep=cygutils-extra) for clipboard support (optional)
 
 ### Installing on Linux
 #### Redhat/Centos

--- a/clipboard.c
+++ b/clipboard.c
@@ -49,7 +49,8 @@ void clipboard_open(void)
 		execlp("xclip", "xclip", "-selection", "clipboard", "-in", NULL);
 		execlp("xsel", "xsel", "--clipboard", "--input", NULL);
 		execlp("pbcopy", "pbcopy", NULL);
-		die("Unable to copy contents to clipboard. Please make sure you have `xclip`, `xsel`, or `pbcopy` installed.");
+		execlp("putclip", "putclip", "--dos", NULL);
+		die("Unable to copy contents to clipboard. Please make sure you have `xclip`, `xsel`, `pbcopy`, or `putclip` installed.");
 	}
 	close(pipefd[0]);
 	dup2(pipefd[1], STDOUT_FILENO);

--- a/lpass.1.txt
+++ b/lpass.1.txt
@@ -119,8 +119,8 @@ will create a duplicate entry of the one specified, but with a different 'ID'.
 Clipboard
 ~~~~~~~~~
 Commands that take a '-c' or '--clip' option will copy the output to the
-clipboard, using *xclip*(1) or *xsel*(1) on X11-based systems or *pbcopy*(1)
-on OSX.
+clipboard, using *xclip*(1) or *xsel*(1) on X11-based systems, *pbcopy*(1)
+on OSX, or *putclip* on Cygwin.
 
 Configuration
 ~~~~~~~~~~~~~


### PR DESCRIPTION
- Add putclip from cygutils-extra as a command for clipboard_open and
  mention it in the docs.
- Add lpass.exe to .gitignore.

Signed-off-by: Douglas Thrift douglas@douglasthrift.net
