### PR TITLE
Update find_unique_account to do substring matches

### DIFF
--- a/cmd.c
+++ b/cmd.c
@@ -71,7 +71,7 @@ struct account *find_unique_account(struct blob *blob, const char *name)
 		}
 		if (!found) {
 			for (struct account *account = blob->account_head; account; account = account->next) {
-				if (!strcmp(account->name, name)) {
+				if (strstr(account->name, name)) {
 					if (found)
 						die("Multiple matches found for '%s'. You must specify an ID instead of a name.", name);
 					found = account;


### PR DESCRIPTION
What does everyone think of this? There is likely better ways to do this or make it a command line option or configurable, but I thought I'd get everyone's feedback.

I made a tiny update to find_unique_account to match on unique substrings. The existing code already checks to see if the match is unique or not, so this allows for a bit simpler searching, and fits my mental model a bit more. Thoughts?

Signed-off-by: Michael Swieton <mike@swieton.net>