### PR TITLE
Added dependencies for Redhat-based distros to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ C99 command line interface to [LastPass.com](https://lastpass.com/).
 * Install the needed dependencies
 
 ```
-sudo yum install openssl libcurl libxml2 pinentry xclip
+sudo yum install openssl libcurl libxml2 pinentry xclip libxml2-devel libcurl-devel
 ```
 
 


### PR DESCRIPTION
In order to build the binary we actually need the *-devel packages of the libxml2 and libcurl libs.
