### PR TITLE
Update debian Build-Depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: lastpass-cli
 Section: misc
 Priority: extra
 Maintainer: Igor Partola <igor@igorpartola.com>
-Build-Depends: debhelper (>= 8.0.0), libssl-dev, libcurl4-openssl-dev, libxml2-dev, asciidoc
+Build-Depends: debhelper (>= 8.0.0), libssl-dev, libcurl4-openssl-dev, libxml2-dev, asciidoc, libxml2-utils, xsltproc, docbook-xsl
 Standards-Version: 3.9.3
 Homepage: https://github.com/lastpass/lastpass-cli
 


### PR DESCRIPTION
Update Debian Build-Depends to include packages necessary for a build to succeed on a buildd lacking recommended packages (libxml2-utils and xsltproc) and network access (docbook-xml), this allows the build to succeed on the Ubuntu build farm.

Signed-off-by: Dave Lawson dave.lawson@canonical.com
