### PR TITLE
Support OpenBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ LDLIBS = -lcurl -lxml2 -lssl -lcrypto
 else
 CFLAGS += $(shell pkg-config --cflags libxml-2.0 2>/dev/null || echo -I/usr/include/libxml2) -I/usr/local/include
 LDLIBS = -lcurl $(shell pkg-config --libs libxml-2.0 2>/dev/null || echo -lxml2) -lssl -lcrypto
+ifeq ($(UNAME_S),OpenBSD)
+LDLIBS += -lkvm
+endif
 endif
 
 all: lpass

--- a/process.c
+++ b/process.c
@@ -17,6 +17,11 @@
 #elif defined(__APPLE__) && defined(__MACH__)
 #include <libproc.h>
 #include <sys/ptrace.h>
+#elif defined(__OpenBSD__)
+#include <sys/param.h>
+#include <sys/proc.h>
+#include <sys/sysctl.h>
+#include <kvm.h>
 #endif
 
 void process_set_name(const char *name)
@@ -85,6 +90,49 @@ bool process_is_same_executable(pid_t pid)
 void process_disable_ptrace(void)
 {
 	ptrace(PT_DENY_ATTACH, 0, 0, 0);
+	struct rlimit limit = { 0, 0 };
+	setrlimit(RLIMIT_CORE, &limit);
+}
+#elif defined(__OpenBSD__)
+int pid_to_cmd(pid_t pid, char *cmd)
+{
+	int cnt, ret;
+	kvm_t *kd;
+	struct kinfo_proc *kp;
+
+	ret = -1;
+
+	if ((kd = kvm_openfiles(NULL, NULL, NULL, KVM_NO_FILES, NULL)) == NULL)
+		return ret;
+	if ((kp = kvm_getprocs(kd, KERN_PROC_PID, (int)pid, sizeof(*kp), &cnt)) == NULL)
+		goto out;
+	if ((kp->p_flag & P_SYSTEM) != 0)
+		goto out;
+	if (cnt != 1)
+		goto out;
+	if (strlcpy(cmd, kp[0].p_comm, sizeof(cmd)) >= sizeof(cmd))
+		goto out;
+
+	ret = 0;
+
+out:
+	kvm_close(kd);
+	return ret;
+}
+
+bool process_is_same_executable(pid_t pid)
+{
+	char resolved_them[PATH_MAX], resolved_me[PATH_MAX];
+
+	if (pid_to_cmd(pid, resolved_them) || pid_to_cmd(getpid(), resolved_me))
+		return false;
+	if (strcmp(resolved_them, resolved_me))
+		return false;
+	return true;
+}
+
+void process_disable_ptrace(void)
+{
 	struct rlimit limit = { 0, 0 };
 	setrlimit(RLIMIT_CORE, &limit);
 }

--- a/process.c
+++ b/process.c
@@ -94,7 +94,7 @@ void process_disable_ptrace(void)
 	setrlimit(RLIMIT_CORE, &limit);
 }
 #elif defined(__OpenBSD__)
-int pid_to_cmd(pid_t pid, char *cmd)
+int pid_to_cmd(pid_t pid, char *cmd, size_t cmd_size)
 {
 	int cnt, ret;
 	kvm_t *kd;
@@ -110,7 +110,7 @@ int pid_to_cmd(pid_t pid, char *cmd)
 		goto out;
 	if (cnt != 1)
 		goto out;
-	if (strlcpy(cmd, kp[0].p_comm, sizeof(cmd)) >= sizeof(cmd))
+	if (strlcpy(cmd, kp[0].p_comm, cmd_size) >= cmd_size)
 		goto out;
 
 	ret = 0;
@@ -124,7 +124,7 @@ bool process_is_same_executable(pid_t pid)
 {
 	char resolved_them[PATH_MAX], resolved_me[PATH_MAX];
 
-	if (pid_to_cmd(pid, resolved_them) || pid_to_cmd(getpid(), resolved_me))
+	if (pid_to_cmd(pid, resolved_them, sizeof(resolved_them)) || pid_to_cmd(getpid(), resolved_me, sizeof(resolved_me)))
 		return false;
 	if (strcmp(resolved_them, resolved_me))
 		return false;


### PR DESCRIPTION
OpenBSD does not have /proc, as such process_is_same_executable() in process.c requires a bit of help from kvm.