### PR TITLE
PBKDF2 pre-OpenSSL 1.0.0 fallback improvements

### DIFF
--- a/kdf.c
+++ b/kdf.c
@@ -12,13 +12,7 @@
 #include <openssl/sha.h>
 #include <openssl/opensslv.h>
 
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L || !(defined(__APPLE__) && defined(__MACH__))
-static void pdkdf2_hash(const char *username, size_t username_len, const char *password, size_t password_len, int iterations, unsigned char hash[KDF_HASH_LEN])
-{
-	if (!PKCS5_PBKDF2_HMAC(password, password_len, (const unsigned char *)username, username_len, iterations, EVP_sha256(), KDF_HASH_LEN, hash))
-		die("Failed to compute PBKDF2 for %s", username);
-}
-#elif defined(__APPLE__) && defined(__MACH__)
+#if defined(__APPLE__) && defined(__MACH__)
 #include <CommonCrypto/CommonCryptor.h>
 #include <CommonCrypto/CommonKeyDerivation.h>
 static void pdkdf2_hash(const char *username, size_t username_len, const char *password, size_t password_len, int iterations, unsigned char hash[KDF_HASH_LEN])
@@ -27,7 +21,13 @@ static void pdkdf2_hash(const char *username, size_t username_len, const char *p
 		die("Failed to compute PBKDF2 for %s", username);
 }
 #else
-#error Failed to build a suitable PBKDF2-HMAC
+#include "pbkdf2.h"
+
+static void pdkdf2_hash(const char *username, size_t username_len, const char *password, size_t password_len, int iterations, unsigned char hash[KDF_HASH_LEN])
+{
+	if (!PKCS5_PBKDF2_HMAC(password, password_len, (const unsigned char *)username, username_len, iterations, EVP_sha256(), KDF_HASH_LEN, hash))
+		die("Failed to compute PBKDF2 for %s", username);
+}
 #endif
 
 static void sha256_hash(const char *username, size_t username_len, const char *password, size_t password_len, unsigned char hash[KDF_HASH_LEN])

--- a/pbkdf2.c
+++ b/pbkdf2.c
@@ -21,6 +21,9 @@
  */
 
 #include "pbkdf2.h"
+#include <string.h>
+#include <openssl/hmac.h>
+
 #ifndef min
 #define min(a, b) (((a) < (b)) ? (a) : (b))
 #endif

--- a/pbkdf2.c
+++ b/pbkdf2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Thomas Hurst.
+ * Copyright (c) 2014-2015 Thomas Hurst.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,22 +20,20 @@
  * THE SOFTWARE.
  */
 
-#include <string.h>
-#include <openssl/hmac.h>
-
-#if OPENSSL_VERSION_NUMBER < 0x10000000L && !(defined(__APPLE__) && defined(__MACH__))
-
+#include "pbkdf2.h"
 #ifndef min
 #define min(a, b) (((a) < (b)) ? (a) : (b))
 #endif
 
 #if OPENSSL_VERSION_NUMBER >= 0x10000000L
 #define ERR_IFZERO(x) if (!(x)) goto err
+#define ERR_LABEL err:
 #else
 #define ERR_IFZERO(x) (x)
+#define ERR_LABEL
 #endif
 
-int PKCS5_PBKDF2_HMAC(const unsigned char *pass, size_t pass_len,
+int fallback_pkcs5_pbkdf2_hmac(const char *pass, size_t pass_len,
 	const unsigned char *salt, size_t salt_len, unsigned int iterations,
 	const EVP_MD *digest, size_t key_len, unsigned char *output)
 {
@@ -52,6 +50,7 @@ int PKCS5_PBKDF2_HMAC(const unsigned char *pass, size_t pass_len,
 	unsigned char tmp_md[md_len];
 
 	HMAC_CTX_init(&ctx);
+	ERR_IFZERO(HMAC_Init_ex(&ctx, pass, pass_len, digest, NULL));
 
 	while (key_left) {
 		cp_len = min(key_left, md_len);
@@ -62,15 +61,16 @@ int PKCS5_PBKDF2_HMAC(const unsigned char *pass, size_t pass_len,
 		c[2] = (count >> 8) & 0xff;
 		c[3] = (count) & 0xff;
 
-		ERR_IFZERO(HMAC_Init_ex(&ctx, pass, pass_len, digest, NULL));
+		ERR_IFZERO(HMAC_Init_ex(&ctx, NULL, 0, digest, NULL));
 		ERR_IFZERO(HMAC_Update(&ctx, salt, salt_len));
 		ERR_IFZERO(HMAC_Update(&ctx, c, 4));
 		ERR_IFZERO(HMAC_Final(&ctx, tmp_md, NULL));
 		memcpy(out, tmp_md, cp_len);
 
 		for (iter=1; iter < iterations; iter++) {
-			if (HMAC(digest, pass, pass_len, tmp_md, md_len, tmp_md, NULL) == NULL)
-				goto err;
+			ERR_IFZERO(HMAC_Init_ex(&ctx, NULL, 0, digest, NULL));
+			ERR_IFZERO(HMAC_Update(&ctx, tmp_md, md_len));
+			ERR_IFZERO(HMAC_Final(&ctx, tmp_md, NULL));
 
 			for (i = 0; i < cp_len; i++) {
 				out[i] ^= tmp_md[i];
@@ -83,8 +83,7 @@ int PKCS5_PBKDF2_HMAC(const unsigned char *pass, size_t pass_len,
 	}
 	ret = 1;
 
-err:
+ERR_LABEL
 	HMAC_CTX_cleanup(&ctx);
 	return ret;
 }
-#endif

--- a/pbkdf2.h
+++ b/pbkdf2.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2014-2015 Thomas Hurst.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef PBKDF2_H
+#define PBKDF2_H
+
+#include <string.h>
+#include <openssl/hmac.h>
+
+#if OPENSSL_VERSION_NUMBER < 0x10000000L
+#define PKCS5_PBKDF2_HMAC fallback_pkcs5_pbkdf2_hmac
+#endif
+
+int fallback_pkcs5_pbkdf2_hmac(const char *pass, size_t pass_len,
+	const unsigned char *salt, size_t salt_len, unsigned int iterations,
+	const EVP_MD *digest, size_t key_len, unsigned char *output);
+#endif

--- a/pbkdf2.h
+++ b/pbkdf2.h
@@ -23,8 +23,7 @@
 #ifndef PBKDF2_H
 #define PBKDF2_H
 
-#include <string.h>
-#include <openssl/hmac.h>
+#include <openssl/evp.h>
 
 #if OPENSSL_VERSION_NUMBER < 0x10000000L
 #define PKCS5_PBKDF2_HMAC fallback_pkcs5_pbkdf2_hmac


### PR DESCRIPTION
Drastically increase performance by pre-initializing the HMAC context prior to iterating.

Rename the function and always compile it so it always gets compile-checked and is easier to test/use on newer OpenSSL's.

Simplify preprocessor logic.

Squish a warning under OpenSSL <1.0.0 (err label unused).

Tested on FreeBSD 10.2-BETA2 and a 9.3 jail environment with OpenSSL 1.0.2d and 0.9.8zd.