### PR TITLE
Editing an empty item via "--notes" now creates a secure note.

### DIFF
--- a/cmd-edit.c
+++ b/cmd-edit.c
@@ -201,7 +201,12 @@ int cmd_edit(int argc, char **argv)
 		account_set_fullname(editable, xstrdup(name), key);
 		account_set_username(editable, xstrdup(""), key);
 		account_set_note(editable, xstrdup(""), key);
-		editable->url = xstrdup("");
+		if (choice == NOTES) {
+			editable->url = xstrdup("http://sn");
+		}
+		else {
+			editable->url = xstrdup("");
+		}
 		list_add(&editable->list, &blob->account_head);
 	}
 	notes_expansion = notes_expand(editable);
@@ -235,6 +240,7 @@ int cmd_edit(int argc, char **argv)
 		value = editable_field->value;
 	} else if (choice == NOTES)
 		value = editable->note;
+
 
 	if (!non_interactive) {
 		if (editable->pwprotect) {


### PR DESCRIPTION
Signed-off-by: Lloyd Zusman <hippoman@potamuses.net>