### PR TITLE
Add documentation for LPASS_ASKPASS.

### DIFF
--- a/lpass.1.txt
+++ b/lpass.1.txt
@@ -76,6 +76,20 @@ passwords if it is installed. If unavailable, or if the 'LPASS_DISABLE_PINENTRY'
 environment variable is set to 1, passwords will be read from standard input and a
 prompt will be displayed on standard error.
 
+The program used for inputting passwords may also be configured by setting the
+'LPASS_ASKPASS` environment variable. 'LPASS_ASKPASS' is expected to be a
+binary that produces a prompt using its first command-line argument, and
+outputs the entered password to standard out.  ssh-askpass implements this
+protocol, as does the following shell script:
+
+[verse]
+ #!/bin/bash
+ echo -n "$*: " >/dev/stderr
+ stty -echo
+ read answer
+ stty echo
+ echo $answer
+
 Entry Specification
 ~~~~~~~~~~~~~~~~~~~
 Commands that take a 'UNIQUENAME' will fail if the provided name is used
@@ -175,4 +189,5 @@ in the section above:
 * 'LPASS_AGENT_TIMEOUT'
 * 'LPASS_AGENT_DISABLE'
 * 'LPASS_DISABLE_PINENTRY'
+* 'LPASS_ASKPASS'
 * 'LPASS_CLIPBOARD_COMMAND'

--- a/lpass.1.txt
+++ b/lpass.1.txt
@@ -143,7 +143,8 @@ Clipboard
 ~~~~~~~~~
 Commands that take a '-c' or '--clip' option will copy the output to the
 clipboard, using *xclip*(1) or *xsel*(1) on X11-based systems, *pbcopy*(1)
-on OSX, or *putclip* on Cygwin.
+on OSX, or *putclip* on Cygwin. The command to be used can be overridden by
+specifying the `LPASS_CLIPBOARD_COMMAND` environment variable.
 
 Color Output
 ~~~~~~~~~~~~
@@ -174,3 +175,4 @@ in the section above:
 * 'LPASS_AGENT_TIMEOUT'
 * 'LPASS_AGENT_DISABLE'
 * 'LPASS_DISABLE_PINENTRY'
+* 'LPASS_CLIPBOARD_COMMAND'


### PR DESCRIPTION
This depends trivially on #121 since they both touch the same list in the manpage. I can trivially rebase this, if desired.

The documentation is mostly extracted from the commit introducing the feature.