### PR TITLE
Move definition to initilization for cleanup decorated variables.

### DIFF
--- a/agent.c
+++ b/agent.c
@@ -103,7 +103,6 @@ static int agent_socket_get_cred(int fd, struct ucred *cred)
 
 static void agent_run(unsigned const char key[KDF_HASH_LEN])
 {
-	_cleanup_free_ char *path;
 	char *agent_timeout_str;
 	unsigned int agent_timeout;
 	struct sockaddr_un sa, listensa;
@@ -123,7 +122,7 @@ static void agent_run(unsigned const char key[KDF_HASH_LEN])
 	if (agent_timeout)
 		alarm(agent_timeout);
 
-	path = agent_socket_path();
+	_cleanup_free_ char *path = agent_socket_path();
 	if (strlen(path) >= sizeof(sa.sun_path))
 		die("Path too large for agent control socket.");
 
@@ -170,12 +169,11 @@ static void agent_run(unsigned const char key[KDF_HASH_LEN])
 
 void agent_kill(void)
 {
-	_cleanup_free_ char *path;
 	struct sockaddr_un sa;
 	struct ucred cred;
 	int fd;
 
-	path = agent_socket_path();
+	_cleanup_free_ char *path = agent_socket_path();
 	if (strlen(path) >= sizeof(sa.sun_path))
 		die("Path too large for agent control socket.");
 
@@ -205,12 +203,11 @@ out:
 
 static bool agent_ask(unsigned char key[KDF_HASH_LEN])
 {
-	_cleanup_free_ char *path;
 	struct sockaddr_un sa;
 	int fd;
 	bool ret = false;
 
-	path = agent_socket_path();
+	_cleanup_free_ char *path = agent_socket_path();
 	if (strlen(path) >= sizeof(sa.sun_path))
 		die("Path too large for agent control socket.");
 

--- a/blob.c
+++ b/blob.c
@@ -581,12 +581,11 @@ size_t blob_write(const struct blob *blob, const unsigned char key[KDF_HASH_LEN]
 {
 	struct buffer buffer;
 	struct share *last_share = NULL;
-	_cleanup_free_ char *version;
 	struct account *account;
 
 	memset(&buffer, 0, sizeof(buffer));
 
-	version = xultostr(blob->version);
+	_cleanup_free_ char *version = xultostr(blob->version);
 	buffer_append(&buffer, "LPAV", 4);
 	write_plain_string(&buffer, version);
 	buffer_append(&buffer, "LOCL", 4);

--- a/cmd-ls.c
+++ b/cmd-ls.c
@@ -99,11 +99,9 @@ static void print_node(struct node *head, int level)
 				printf("    ");
 			if (node->account) {
 				if (long_listing) {
-					_cleanup_free_ char *timestr;
-					if (show_mtime)
-						timestr = format_timestamp(node->account->last_modified_gmt, true);
-					else
-						timestr = format_timestamp(node->account->last_touch, false);
+					_cleanup_free_ char *timestr = show_mtime ?
+						format_timestamp(node->account->last_modified_gmt, true) :
+						format_timestamp(node->account->last_touch, false);
 					terminal_printf(TERMINAL_FG_CYAN "%s ", timestr);
 				}
 				terminal_printf(TERMINAL_FG_GREEN TERMINAL_BOLD "%s" TERMINAL_NO_BOLD " [id: %s]" TERMINAL_RESET "\n", node->name, node->account->id);
@@ -214,11 +212,9 @@ int cmd_ls(int argc, char **argv)
 			insert_node(root, fullname, account);
 		else {
 			if (long_listing) {
-				_cleanup_free_ char *timestr;
-				if (show_mtime)
-					timestr = format_timestamp(account->last_modified_gmt, true);
-				else
-					timestr = format_timestamp(account->last_touch, false);
+				_cleanup_free_ char *timestr = show_mtime ?
+					format_timestamp(account->last_modified_gmt, true) :
+					format_timestamp(account->last_touch, false);
 				printf("%s ", timestr);
 			}
 			printf("%s [id: %s]\n", fullname, account->id);

--- a/endpoints.c
+++ b/endpoints.c
@@ -33,9 +33,8 @@ void lastpass_logout(const struct session *session)
 struct blob *lastpass_get_blob(const struct session *session, const unsigned char key[KDF_HASH_LEN])
 {
 	size_t len;
-	_cleanup_free_ char *blob;
 
-	blob = http_post_lastpass("getaccts.php", session->sessionid, &len, "mobile", "1", "requestsrc", "cli", "hasplugin", LASTPASS_CLI_VERSION, NULL);
+	_cleanup_free_ char *blob = http_post_lastpass("getaccts.php", session->sessionid, &len, "mobile", "1", "requestsrc", "cli", "hasplugin", LASTPASS_CLI_VERSION, NULL);
 	if (!blob || !len)
 		return NULL;
 	config_write_encrypted_buffer("blob", blob, len, key);

--- a/lpass.c
+++ b/lpass.c
@@ -83,11 +83,10 @@ static void expand_aliases(int *argc, char ***argv)
 	int argv_alloced;
 	int new_argc = 0;
 	_cleanup_free_ char *config_name;
-	_cleanup_free_ char *alias_val;
 
 	xasprintf(&config_name, "alias.%s", alias);
 
-	alias_val = config_read_string(config_name);
+	_cleanup_free_ char *alias_val = config_read_string(config_name);
 	if (!alias_val)
 		return;
 


### PR DESCRIPTION
Fixes #128.

gcc otherwise thinks they are potenitally used uninitialized when
`-fexceptions` is set. This is due to potenitally calling free when
unwinding before the initialization (often the exception is thought to
come from the function that does the initializiation.

---

I'm not sure if this is the best approach, but taking advantage of C99's ability to interweave code and definitions seems to make sense.