### PR TITLE
generate: add --only

### DIFF
--- a/cmd-generate.c
+++ b/cmd-generate.c
@@ -48,67 +48,15 @@
 #define NICE_CHARS_LEN 62
 static char *chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890`~!@#$%^&*()-_=+[{]}\\|;:'\",<.>/?";
 
-int cmd_generate(int argc, char **argv)
+static void update_account(char *username, char *url, char *name, enum blobsync sync, char *password)
 {
 	unsigned char key[KDF_HASH_LEN];
 	struct session *session = NULL;
 	struct blob *blob = NULL;
-	static struct option long_options[] = {
-		{"sync", required_argument, NULL, 'S'},
-		{"username", required_argument, NULL, 'U'},
-		{"url", required_argument, NULL, 'L'},
-		{"no-symbols", no_argument, NULL, 'X'},
-		{"clip", no_argument, NULL, 'c'},
-		{0, 0, 0, 0}
-	};
-	char option;
-	int option_index;
-	char *username = NULL;
-	char *url = NULL;
-	bool no_symbols = false;
-	unsigned long length;
-	char *name;
-	enum blobsync sync = BLOB_SYNC_AUTO;
-	_cleanup_free_ char *password = NULL;
-	struct account *new = NULL, *found;
+	struct account *new = NULL, *found = NULL;
 	struct account *notes_expansion, *notes_collapsed = NULL;
-	bool clip = false;
-
-	while ((option = getopt_long(argc, argv, "c", long_options, &option_index)) != -1) {
-		switch (option) {
-			case 'S':
-				sync = parse_sync_string(optarg);
-				break;
-			case 'U':
-				username = xstrdup(optarg);
-				break;
-			case 'L':
-				url = xstrdup(optarg);
-				break;
-			case 'X':
-				no_symbols = true;
-				break;
-			case 'c':
-				clip = true;
-				break;
-			case '?':
-			default:
-				die_usage(cmd_generate_usage);
-		}
-	}
-
-	if (argc - optind != 2)
-		die_usage(cmd_generate_usage);
-	name = argv[optind];
-	length = strtoul(argv[optind + 1], NULL, 10);
-	if (!length)
-		die_usage(cmd_generate_usage);
 
 	init_all(sync, key, &session, &blob);
-
-	password = xcalloc(length + 1, 1);
-	for (size_t i = 0; i < length; ++i)
-		password[i] = chars[range_rand(0, no_symbols ? NICE_CHARS_LEN : ALL_CHARS_LEN)];
 
 	found = find_unique_account(blob, name);
 	if (found) {
@@ -149,12 +97,77 @@ int cmd_generate(int argc, char **argv)
 	lastpass_update_account(sync, key, session, found ? found : new, blob);
 	blob_save(blob, key);
 
+	session_free(session);
+	blob_free(blob);
+}
+
+int cmd_generate(int argc, char **argv)
+{
+	static struct option long_options[] = {
+		{"sync", required_argument, NULL, 'S'},
+		{"username", required_argument, NULL, 'U'},
+		{"url", required_argument, NULL, 'L'},
+		{"no-symbols", no_argument, NULL, 'X'},
+		{"only", no_argument, NULL, 'O'},
+		{"clip", no_argument, NULL, 'c'},
+		{0, 0, 0, 0}
+	};
+	char option;
+	int option_index;
+	char *username = NULL;
+	char *url = NULL;
+	bool no_symbols = false;
+	bool only = false;
+	unsigned long length;
+	char *name;
+	enum blobsync sync = BLOB_SYNC_AUTO;
+	_cleanup_free_ char *password = NULL;
+	bool clip = false;
+
+	while ((option = getopt_long(argc, argv, "c", long_options, &option_index)) != -1) {
+		switch (option) {
+			case 'S':
+				sync = parse_sync_string(optarg);
+				break;
+			case 'U':
+				username = xstrdup(optarg);
+				break;
+			case 'L':
+				url = xstrdup(optarg);
+				break;
+			case 'X':
+				no_symbols = true;
+				break;
+			case 'O':
+				only = true;
+				break;
+			case 'c':
+				clip = true;
+				break;
+			case '?':
+			default:
+				die_usage(cmd_generate_usage);
+		}
+	}
+
+	if (argc - optind != 2)
+		die_usage(cmd_generate_usage);
+	name = argv[optind];
+	length = strtoul(argv[optind + 1], NULL, 10);
+	if (!length)
+		die_usage(cmd_generate_usage);
+
+	password = xcalloc(length + 1, 1);
+	for (size_t i = 0; i < length; ++i)
+		password[i] = chars[range_rand(0, no_symbols ? NICE_CHARS_LEN : ALL_CHARS_LEN)];
+
+        if (!only)
+		update_account(username, url, name, sync, password);
+
 	if (clip)
 		clipboard_open();
 
 	printf("%s\n", password);
 
-	session_free(session);
-	blob_free(blob);
 	return 0;
 }

--- a/cmd.h
+++ b/cmd.h
@@ -56,7 +56,7 @@ int cmd_edit(int argc, char **argv);
 #define cmd_edit_usage "edit [--sync=auto|now|no] [--non-interactive] " color_usage " {--name|--username|--password|--url|--notes|--field=FIELD} {NAME|UNIQUEID}"
 
 int cmd_generate(int argc, char **argv);
-#define cmd_generate_usage "generate [--sync=auto|now|no] [--clip, -c] [--username=USERNAME] [--url=URL] [--no-symbols] {NAME|UNIQUEID} LENGTH"
+#define cmd_generate_usage "generate [--sync=auto|now|no] [--clip, -c] [--username=USERNAME] [--url=URL] [--no-symbols] [--only] {NAME|UNIQUEID} LENGTH"
 
 int cmd_duplicate(int argc, char **argv);
 #define cmd_duplicate_usage "duplicate [--sync=auto|now|no] " color_usage " {UNIQUENAME|UNIQUEID}"

--- a/lpass.1.txt
+++ b/lpass.1.txt
@@ -27,7 +27,7 @@ several subcommands:
  lpass *show* [--sync=auto|now|no] [--clip, -c] [--all|--username|--password|--url|--notes|--field=FIELD|--id|--name] [--basic-regexp, -G|--fixed-strings, -F] [--color=auto|never|always] {NAME|UNIQUEID}
  lpass *ls* [--sync=auto|now|no] [--long, -l] [-m] [-u] [--color=auto|never|always] [GROUP]
  lpass *edit* [--sync=auto|now|no] [--non-interactive] {--name|--username, -u|--password, -p|--url|--notes|--field=FIELD} [--color=auto|never|always] {NAME|UNIQUEID}
- lpass *generate* [--sync=auto|now|no] [--clip, -c] [--username=USERNAME] [--url=URL] [--no-symbols] [--color=auto|never|always] {NAME|UNIQUEID} LENGTH
+ lpass *generate* [--sync=auto|now|no] [--clip, -c] [--username=USERNAME] [--url=URL] [--no-symbols] [--only] [--color=auto|never|always] {NAME|UNIQUEID} LENGTH
  lpass *duplicate* [--sync=auto|now|no] [--color=auto|never|always] {UNIQUENAME|UNIQUEID}
  lpass *rm* [--sync=auto|now|no] [--color=auto|never|always] {UNIQUENAME|UNIQUEID}
  lpass *sync* [--background, -b] [--color=auto|never|always]


### PR DESCRIPTION
This change allows users to generate a password without loading or
syncing a session.

Example usage:

        $ lpass generate --only hodor 42
        t<vh6C+.JVu;eH=Ot--l]C+TxOritc.&j6@&)7By7B