### PR TITLE
Added dependency for documentation installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Command line interface to [LastPass.com](https://lastpass.com/).
 sudo yum install openssl libcurl libxml2 pinentry xclip openssl-devel libxml2-devel libcurl-devel
 ```
 
+* (Optional) Install the needed documentation dependencies, then follow the instructions in the 'Documentation' section.
+```
+sudo yum install asciidoc
+```
+
 
 #### Debian/Ubuntu
 * Install the needed build dependencies, and then follow instructions in


### PR DESCRIPTION
asciidoc is required for installing the documentation on Fedora.

Otherwise you get:
```
❯ sudo make install-doc                                                                                                                                                                                 [159/96398]
a2x --no-xmllint -f manpage lpass.1.txt
make: a2x: Command not found
Makefile:36: recipe for target 'lpass.1' failed
make: *** [lpass.1] Error 127
```