### PR TITLE
export: secure notes support

### DIFF
--- a/blob.c
+++ b/blob.c
@@ -300,7 +300,7 @@ static struct account *account_parse(struct chunk *chunk, const unsigned char ke
 	entry_crypt(group);
 	entry_hex(url);
 	entry_crypt(note);
-	skip(fav);
+	entry_boolean(fav);
 	skip(sharedfromaid);
 	entry_crypt(username);
 	entry_crypt(password);
@@ -454,6 +454,7 @@ struct blob *blob_parse(const unsigned char *blob, size_t len, const unsigned ch
 				xasprintf(&account->fullname, "%s/%s",
 					  last_share->name, tmp);
 				free(tmp);
+				account->group = xstrdup(last_share->name);
 			}
 
 			list_add(&account->list, &parsed->account_head);

--- a/blob.h
+++ b/blob.h
@@ -55,6 +55,7 @@ struct account {
 	char *note, *note_encrypted;
 	char *last_touch, *last_modified_gmt;
 	bool pwprotect;
+	bool fav;
 
 	struct list_head field_head;
 	struct share *share;

--- a/cmd-export.c
+++ b/cmd-export.c
@@ -122,20 +122,27 @@ int cmd_export(int argc, char **argv)
 		}
 	}
 
-	printf("url,username,password,hostname,name,grouping\r\n");
+	printf("url,username,password,extra,name,grouping,fav\r\n");
+
 	list_for_each_entry(account, &blob->account_head, list) {
 
-		/* skip shared notes */
-		if (!strcmp(account->url, "http://sn"))
+		/* skip groups */
+		if (!strcmp(account->url, "http://group"))
 			continue;
 
 		lastpass_log_access(sync, session, key, account);
 		print_csv_cell(account->url, false);
 		print_csv_cell(account->username, false);
 		print_csv_cell(account->password, false);
-		print_csv_cell(account->fullname, false);
+		print_csv_cell(account->note, false);
 		print_csv_cell(account->name, false);
-		print_csv_cell(account->group, true);
+		print_csv_cell(account->group, false);
+		if(account->fav) {
+			print_csv_cell("1", true);
+		} else {
+			print_csv_cell("0", true);
+		}
+
 	}
 
 	session_free(session);


### PR DESCRIPTION
This is pretty much the bare-minimum necessary to bring the export format for lastpass-cli into sync with the browser extension.

## Changes

- Add support for secure notes in export
- Use the same csv fields as the browser extension uses
- Skip 'http://group' entries - these are just groups, not passwords or
  notes
- Add account-fav to account struct
- Support account->group for shared folders

## Does Not Support
- Extracting password from notes and putting it in the password field

Fixes github issue #104