### PR TITLE
Make it easier to distinguish between multiple accounts with one website

### DIFF
--- a/cmd-ls.c
+++ b/cmd-ls.c
@@ -217,7 +217,11 @@ static void print_node(struct node *head, int level)
 						format_timestamp(node->account->last_touch, false);
 					terminal_printf(TERMINAL_FG_CYAN "%s ", timestr);
 				}
-				terminal_printf(TERMINAL_FG_GREEN TERMINAL_BOLD "%s" TERMINAL_NO_BOLD " [id: %s]" TERMINAL_RESET "\n", node->name, node->account->id);
+				terminal_printf(TERMINAL_FG_GREEN TERMINAL_BOLD "%s" TERMINAL_NO_BOLD " [id: %s] ", node->name, node->account->id);
+				if (long_listing) {
+					terminal_printf(TERMINAL_FG_GREEN "[username: %s] ", node->account->username);
+				}
+				terminal_printf(TERMINAL_RESET "\n");
 			}
 			else if (node->shared)
 				terminal_printf(TERMINAL_FG_CYAN TERMINAL_BOLD "%s" TERMINAL_RESET "\n", node->name);

--- a/cmd.h
+++ b/cmd.h
@@ -84,7 +84,7 @@ int cmd_show(int argc, char **argv);
 #define cmd_show_usage "show [--sync=auto|now|no] [--clip, -c] [--expand-multi, -x] [--all|--username|--password|--url|--notes|--field=FIELD|--id|--name] [--basic-regexp, -G|--fixed-strings, -F] " color_usage " {UNIQUENAME|UNIQUEID}"
 
 int cmd_ls(int argc, char **argv);
-#define cmd_ls_usage "ls [--sync=auto|now|no] [--long, -l] " color_usage " [GROUP]"
+#define cmd_ls_usage "ls [--sync=auto|now|no] [--long, -l] [-m] [-u] " color_usage " [GROUP]"
 
 int cmd_add(int argc, char **argv);
 #define cmd_add_usage "add [--sync=auto|now|no] [--non-interactive] " color_usage " {--username|--password|--url|--notes|--field=FIELD} NAME"


### PR DESCRIPTION
Print the username when using ls --long.
The username can now be seen without multiple show commands.
This allows for the correct one to be selected the first time or found with grep.

Also, update usage string for ls command to match with code and docs 