### PR TITLE
Update README.md (cygwin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ sudo make -C /usr/ports/security/lastpass-cli all install clean
   instructions in the 'Building' section.
 
 ```
-apt-cyg install wget make gcc-core openssl-devel libcurl-devel libxml2-devel cygutils-extra
+apt-cyg install wget make gcc-core openssl-devel libcurl-devel libxml2-devel cygutils-extra libiconv-devel
 ```
 
 ## Building


### PR DESCRIPTION
Cygwin requires libiconv-devel to be installed before it's able to build xml.o to then build the project. Have updated the README.md to reflect this.

cc -O3 -march=native -fomit-frame-pointer -pipe -std=gnu99 -D_GNU_SOURCE -pedantic -Wall -Wextra -Wno-language-extension-token -MMD -I/usr/include/libxml2 -I/usr/local/include   -c -o xml.o xml.c
In file included from /usr/include/libxml2/libxml/parser.h:810:0,
                 from xml.c:40:
/usr/include/libxml2/libxml/encoding.h:28:19: fatal error: iconv.h: No such file or directory
compilation terminated.
make: *** [<builtin>: xml.o] Error 1
