### PR TITLE
Fix ALL_CHARS_LEN in cmd-generate.c to use all characters

### DIFF
--- a/cmd-generate.c
+++ b/cmd-generate.c
@@ -44,9 +44,9 @@
 #include <stdio.h>
 #include <string.h>
 
-#define ALL_CHARS_LEN 94
+static char chars[] = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890`~!@#$%^&*()-_=+[{]}\\|;:'\",<.>/?";
+#define ALL_CHARS_LEN (sizeof(chars) - 1)
 #define NICE_CHARS_LEN 62
-static char *chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890`~!@#$%^&*()-_=+[{]}\\|;:'\",<.>/?";
 
 int cmd_generate(int argc, char **argv)
 {


### PR DESCRIPTION
Currently ALL_CHARS_LEN is 94, however there are 96 characters in the char string. That means not all characters are used for password generation.