### PR TITLE
Added bash completion in %files

### DIFF
--- a/contrib/specfile/lastpass-cli.spec
+++ b/contrib/specfile/lastpass-cli.spec
@@ -31,6 +31,7 @@ make install-doc DESTDIR=%{?buildroot}
 %files
 /usr/bin/lpass
 /usr/share/man/man1/lpass.1.gz
+/usr/share/bash-completion/completions/lpass
 %doc
 
 


### PR DESCRIPTION
rpmbuild -bb specfile.spec was failing because this wasn't listed. Once added to %files rpmbuild -bb specfile.spec builds the rpm as expected.