### PR TITLE
Sort list of source files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ doc-man: lpass.1
 doc-html: lpass.1.html
 doc: doc-man doc-html
 
-lpass: $(patsubst %.c,%.o,$(wildcard *.c))
+lpass: $(patsubst %.c,%.o,$(sort $(wildcard *.c)))
 %.1: %.1.txt
 	a2x --no-xmllint -f manpage $<
 %.1.html: %.1.txt


### PR DESCRIPTION
$(wildcard) does not guarantee a sorted list, which causes
also a non-deterministic order while linking the binary.
To support reproducible building, the list is explicitely sorted.