### PR TITLE
CMakeLists.txt: Fix system installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ include(GNUInstallDirs)
 
 find_package(PkgConfig REQUIRED)
 
+# pkg_get_variable is not available until CMake >= 3.4.0
+# Debian stable still packages CMake 3.0.2
 function(pkg_check_variable _pkg _name)
   string(TOUPPER ${_pkg} _pkg_upper)
   string(TOUPPER ${_name} _name_upper)
@@ -55,12 +57,17 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
   COMPILE_DEFINITIONS ${PROJECT_DEFINITIONS}
 )
 target_link_libraries(${PROJECT_NAME} ${LIBXML2_LIBRARIES} ${OPENSSL_LIBRARIES} ${CURL_LIBRARIES})
+
+add_custom_command(OUTPUT lpass.1 DEPENDS ${CMAKE_SOURCE_DIR}/lpass.1.txt
+        COMMAND a2x -D ./ --no-xmllint -f manpage ${CMAKE_SOURCE_DIR}/lpass.1.txt)
+add_custom_command(OUTPUT lpass.1.html DEPENDS ${CMAKE_SOURCE_DIR}/lpass.1.txt
+        COMMAND asciidoc -b html5 -a data-uri -a icons -a toc2 -o lpass.1.html ${CMAKE_SOURCE_DIR}/lpass.1.txt)
+
 install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin)
-if(BASH_COMPLETION_COMPLETIONSDIR)
-  install(FILES contrib/lpass_bash_completion DESTINATION ${BASH_COMPLETION_COMPLETIONSDIR} RENAME lpass)
-endif()
+install(FILES contrib/lpass_bash_completion DESTINATION ${BASH_COMPLETION_COMPLETIONSDIR} RENAME lpass)
 
-add_custom_target(doc-man a2x --no-xmllint -f manpage ${CMAKE_SOURCE_DIR}/lpass.1.txt)
-add_custom_target(doc asciidoc -b html5 -a data-uri -a icons -a toc2 -o lpass.1.html ${CMAKE_SOURCE_DIR}/lpass.1.txt DEPENDS doc-man)
-add_custom_target(install-doc install -v -d ${CMAKE_INSTALL_FULL_MANDIR}/man1 && install -m 0644 -v lpass.1 ${CMAKE_INSTALL_FULL_MANDIR}/man1/lpass.1 DEPENDS doc)
-
+add_custom_target(doc-man DEPENDS lpass.1)
+add_custom_target(doc-html DEPENDS lpass.1.html)
+# See https://cmake.org/pipermail/cmake/2009-January/026520.html
+add_custom_target(install-doc COMMAND ${CMAKE_COMMAND} -DMANDIR=${CMAKE_INSTALL_FULL_MANDIR} -P ${CMAKE_SOURCE_DIR}/cmake_extras/install_doc.cmake DEPENDS doc-man)
+add_custom_target(uninstall COMMAND ${CMAKE_COMMAND} -DPROJECT_NAME=${PROJECT_NAME} -DMANDIR=${CMAKE_INSTALL_FULL_MANDIR} -P ${CMAKE_SOURCE_DIR}/cmake_extras/uninstall.cmake)

--- a/cmake_extras/install_doc.cmake
+++ b/cmake_extras/install_doc.cmake
@@ -1,0 +1,1 @@
+execute_process(COMMAND install -Dm644 -v ${CMAKE_BINARY_DIR}/lpass.1 $ENV{DESTDIR}${MANDIR}/man1/lpass.1)

--- a/cmake_extras/uninstall.cmake
+++ b/cmake_extras/uninstall.cmake
@@ -1,0 +1,33 @@
+################ CMake Uninstall Template #######################
+# Used for generating a "make uninstall" target
+#################################################################
+
+set(MANIFEST "${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt")
+
+if(EXISTS ${MANIFEST})
+    message(STATUS "============== Uninstalling ${PROJECT_NAME} ===================")
+
+    file(STRINGS ${MANIFEST} files)
+    set (files ${files} "${MANDIR}/man1/lpass.1")
+    foreach(file ${files})
+        set(file "$ENV{DESTDIR}${file}")
+        if(EXISTS ${file})
+            message(STATUS "Removing file: '${file}'")
+
+            execute_process(
+                COMMAND ${CMAKE_COMMAND} -E remove ${file}
+                OUTPUT_VARIABLE rm_out
+                RESULT_VARIABLE rm_retval
+            )
+
+            if( rm_retval )
+                message(FATAL_ERROR "Failed to remove file: '${file}'.")
+            endif()
+        else()
+            message(STATUS "File '${file}' does not exist.")
+        endif()
+    endforeach(file)
+else()
+    message(STATUS "Cannot find install manifest: '${MANIFEST}'")
+    message(STATUS "Have you *actually* run `make install` yet?")
+endif()


### PR DESCRIPTION
This fixes #227 and also serves as a bit of testimony to how complicated CMake can be...
CMake doesn't like custom install targets and is way too overprotective of its environment variables, so doing this properly requires shelling out to a custom script (per nonstandard target) instead. Oh well, at least it does the right thing on Windows. :smile: