### PR TITLE
Fix compiling when using LibreSSL

### DIFF
--- a/pbkdf2.c
+++ b/pbkdf2.c
@@ -53,7 +53,7 @@ int fallback_pkcs5_pbkdf2_hmac(const char *pass, size_t pass_len,
 
 	unsigned char tmp_md[md_len];
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 	HMAC_CTX real_ctx;
 	ctx = &real_ctx;
 	HMAC_CTX_init(ctx);
@@ -97,7 +97,7 @@ int fallback_pkcs5_pbkdf2_hmac(const char *pass, size_t pass_len,
 	ret = 1;
 
 ERR_LABEL
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 	HMAC_CTX_cleanup(ctx);
 #else
 	HMAC_CTX_free(ctx);


### PR DESCRIPTION
Fix undefined reference to `HMAC_CTX_new' and `HMAC_CTX_free' when using
LibreSSL instead of OpenSSL.

Signed-off-by: Björn Ketelaars <bjorn.ketelaars@hydroxide.nl>