### PR TITLE
Fix support for OpenBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,9 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
   COMPILE_DEFINITIONS ${PROJECT_DEFINITIONS}
 )
 target_link_libraries(${PROJECT_NAME} ${LIBXML2_LIBRARIES} ${OPENSSL_LIBRARIES} ${CURL_LIBRARIES})
+if (CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
+  target_link_libraries(${PROJECT_NAME} "-lkvm")
+endif (CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
 
 add_custom_command(OUTPUT lpass.1 DEPENDS ${CMAKE_SOURCE_DIR}/lpass.1.txt
         COMMAND a2x -D ./ --no-xmllint -f manpage ${CMAKE_SOURCE_DIR}/lpass.1.txt)


### PR DESCRIPTION
a971ec2d0c7568d0e33ab72ce9622a58bd858c11 removed part of the support for
OpenBSD. Re-add -lkvm to LDLIBS (if lastpass-cli is compiled on
OpenBSD).

Signed-off-by: Björn Ketelaars <bjorn.ketelaars@hydroxide.nl>