### PR TITLE
ls: sort by display fullname

### DIFF
--- a/cmd-ls.c
+++ b/cmd-ls.c
@@ -212,7 +212,10 @@ static int compare_account(const void *a, const void *b)
 {
 	struct account * const *acct_a = a;
 	struct account * const *acct_b = b;
-	return strcmp((*acct_a)->fullname, (*acct_b)->fullname);
+	_cleanup_free_ char *str1 = get_display_fullname(*acct_a);
+	_cleanup_free_ char *str2 = get_display_fullname(*acct_b);
+
+	return strcmp(str1, str2);
 }
 
 int cmd_ls(int argc, char **argv)


### PR DESCRIPTION
Display fullname differs from account name when there is no group;
in this case (none) is prepended to the account, but we sort as
if it isn't there, leading to mixed up sorting.

Signed-off-by: Bob Copeland <copeland@lastpass.com>