### PR TITLE
logging shows file/line; logging helper functions and macros

### DIFF
--- a/http.c
+++ b/http.c
@@ -252,7 +252,7 @@ char *http_post_lastpass_v_noexit(const char *server, const char *page, const st
 
 	xasprintf(&url, "https://%s/%s", login_server, page);
 
-	lpass_log(LOG_DEBUG, "Making request to %s\n", url);
+	LOG_DEBUG( "Making request to %s\n", url);
 
 	curl = curl_easy_init();
 	if (!curl)
@@ -278,7 +278,7 @@ char *http_post_lastpass_v_noexit(const char *server, const char *page, const st
 	curl_easy_setopt(curl, CURLOPT_URL, url);
 	curl_easy_setopt(curl, CURLOPT_USERAGENT, LASTPASS_CLI_USERAGENT);
 
-	if (lpass_log_level() >= LOG_VERBOSE) {
+	if (lpass_log_is_verbose()) {
 		logstream = lpass_log_open();
 		if (logstream) {
 			curl_easy_setopt(curl, CURLOPT_STDERR, logstream);

--- a/log.c
+++ b/log.c
@@ -44,15 +44,44 @@
 
 int lpass_log_level()
 {
+    static int initialized  = 0;
+	static int level = LOG_LEVEL_NONE;
 	char *log_level_str;
-	int level;
+
+    if (initialized)
+        return (enum log_level) level;
 
 	log_level_str = getenv("LPASS_LOG_LEVEL");
 	if (!log_level_str)
-		return LOG_NONE;
+		return LOG_LEVEL_NONE;
 
 	level = strtoul(log_level_str, NULL, 10);
+    initialized = 1;
 	return (enum log_level) level;
+}
+
+int lpass_log_is_none() {
+    return lpass_log_level() >= LOG_LEVEL_NONE;
+}
+
+int lpass_log_is_error() {
+    return lpass_log_level() >= LOG_LEVEL_ERROR;
+}
+
+int lpass_log_is_warning() {
+    return lpass_log_level() >= LOG_LEVEL_WARNING;
+}
+
+int lpass_log_is_info() {
+    return lpass_log_level() >= LOG_LEVEL_INFO;
+}
+
+int lpass_log_is_debug() {
+    return lpass_log_level() >= LOG_LEVEL_DEBUG;
+}
+
+int lpass_log_is_verbose() {
+    return lpass_log_level() >= LOG_LEVEL_VERBOSE;
 }
 
 void lpass_log(enum log_level level, char *fmt, ...)

--- a/log.c
+++ b/log.c
@@ -26,7 +26,7 @@
  * You must obey the GNU General Public License in all respects
  * for all of the code used other than OpenSSL.  If you modify
  * file(s) with this exception, you may extend this exception to your
- * version of the file(s), but you are not obligated to do so.  If you
+ * version of the file(s), but you are not obligated to do so.	If you
  * do not wish to do so, delete this exception statement from your
  * version.  If you delete this exception statement from all source
  * files in the program, then also delete it here.
@@ -37,51 +37,83 @@
 #include "log.h"
 #include "config.h"
 #include <fcntl.h>
+#include <string.h>
 #include <sys/time.h>
 
 #define TIME_FMT "%lld.%06lld"
 #define TIME_ARGS(tv) ((long long)(tv)->tv_sec), ((long long)(tv)->tv_usec)
 
+static int initialized	= 0;
+static int level = LOG_LEVEL_NONE;
+static int log_to_stderr = 0;
+
 int lpass_log_level()
 {
-    static int initialized  = 0;
-	static int level = LOG_LEVEL_NONE;
 	char *log_level_str;
 
-    if (initialized)
-        return (enum log_level) level;
+	if (initialized)
+		return (enum log_level) level;
+
+	if (getenv("LPASS_LOG_STDERR"))
+		lpass_log_set_log_to_stderr();
 
 	log_level_str = getenv("LPASS_LOG_LEVEL");
-	if (!log_level_str)
-		return LOG_LEVEL_NONE;
+	if (!log_level_str) {
+		initialized = true;
+		level = LOG_LEVEL_NONE;
+		return (enum log_level) level;
+	}
 
 	level = strtoul(log_level_str, NULL, 10);
-    initialized = 1;
+	initialized = 1;
 	return (enum log_level) level;
 }
 
+void lpass_log_set_log_to_stderr() {
+	log_to_stderr = 1;
+}
+
+const char* lpass_log_level_string() {
+	if (lpass_log_is_verbose())	return "VERBOSE";
+	if (lpass_log_is_debug())		return "DEBUG";
+	if (lpass_log_is_info())		return "INFO";
+	if (lpass_log_is_warning())	return "WARNING";
+	if (lpass_log_is_error())		return "ERROR";
+	return "NONE";
+}
+
 int lpass_log_is_none() {
-    return lpass_log_level() >= LOG_LEVEL_NONE;
+	return lpass_log_level() >= LOG_LEVEL_NONE;
 }
 
 int lpass_log_is_error() {
-    return lpass_log_level() >= LOG_LEVEL_ERROR;
+	return lpass_log_level() >= LOG_LEVEL_ERROR;
 }
 
 int lpass_log_is_warning() {
-    return lpass_log_level() >= LOG_LEVEL_WARNING;
+	return lpass_log_level() >= LOG_LEVEL_WARNING;
 }
 
 int lpass_log_is_info() {
-    return lpass_log_level() >= LOG_LEVEL_INFO;
+	return lpass_log_level() >= LOG_LEVEL_INFO;
 }
 
 int lpass_log_is_debug() {
-    return lpass_log_level() >= LOG_LEVEL_DEBUG;
+	return lpass_log_level() >= LOG_LEVEL_DEBUG;
 }
 
 int lpass_log_is_verbose() {
-    return lpass_log_level() >= LOG_LEVEL_VERBOSE;
+	return lpass_log_level() >= LOG_LEVEL_VERBOSE;
+}
+
+const char* lpass_short_fname(const char* fname)
+{
+	const char* pos = strrchr(fname, '/');
+	if (!pos) {
+		return fname;
+	}
+
+	return pos+1;
 }
 
 void lpass_log(enum log_level level, char *fmt, ...)
@@ -101,11 +133,19 @@ void lpass_log(enum log_level level, char *fmt, ...)
 		return;
 
 	gettimeofday(&tv, &tz);
-	fprintf(fp, "<%d> [" TIME_FMT "] ", level, TIME_ARGS(&tv));
+	fprintf(fp, "<%-7s> [" TIME_FMT "] ", lpass_log_level_string(level), TIME_ARGS(&tv));
 	va_start(ap, fmt);
 	vfprintf(fp, fmt, ap);
 	va_end(ap);
 	fflush(fp);
+
+
+	if (log_to_stderr) {
+		fprintf(stderr, "<%-7s> [" TIME_FMT "] ", lpass_log_level_string(level), TIME_ARGS(&tv));
+		va_start(ap, fmt);
+		vfprintf(stderr, fmt, ap);
+		va_end(ap);
+	}
 }
 
 FILE *lpass_log_open()
@@ -117,4 +157,9 @@ FILE *lpass_log_open()
 
 	upload_log_path = config_path("lpass.log");
 	return fopen(upload_log_path, "a");
+}
+
+const char* lpass_log_bool_to_string(int b)
+{
+	return b ? "true" : "false";
 }

--- a/log.h
+++ b/log.h
@@ -29,8 +29,8 @@ int lpass_log_is_none();
 void lpass_log(enum log_level level, char *fmt, ...);
 FILE *lpass_log_open();
 
-#define LOG0(level, fmt)      (lpass_log(level, "%s:%d " fmt, __FILE__, __LINE__))
-#define LOG(level, fmt, ...)  (lpass_log(level, "%s:%d " fmt, __FILE__, __LINE__, __VA_ARGS__))
+#define LOG0(level, fmt)      (lpass_log(level, "%s:%d:%s: " fmt, __FILE__, __LINE__, __func__))
+#define LOG(level, fmt, ...)  (lpass_log(level, "%s:%d:%s: " fmt, __FILE__, __LINE__, __func__, __VA_ARGS__))
 
 #define LOG_VERBOSE0(fmt)      if (lpass_log_is_verbose()) LOG0(LOG_LEVEL_VERBOSE, fmt)
 #define LOG_VERBOSE(fmt, ...)  if (lpass_log_is_verbose()) LOG(LOG_LEVEL_VERBOSE, fmt, __VA_ARGS__)

--- a/log.h
+++ b/log.h
@@ -2,12 +2,14 @@
 #define __LOG_H
 
 /*
- * Loglevels for ~/.lpass/lpass.log.  By default, nothing is logged, but
+ * Loglevels for ~/.lpass/lpass.log.	By default, nothing is logged, but
  * setting LPASS_LOG_LEVEL to a positive value will turn on logging.
+ * Setting LPASS_LOG_STDERR to a non-empty string will cause log messages
+ * to be sent to stderr
  *
  * NOTE: debug and verbose logs can include sensitive information such as
- *       session IDs in the clear.  Do NOT post logs in public without
- *       scrubbing them first!
+ *			 session IDs in the clear.	Do NOT post logs in public without
+ *			 scrubbing them first!
  */
 enum log_level
 {
@@ -26,25 +28,29 @@ int lpass_log_is_info();
 int lpass_log_is_warning();
 int lpass_log_is_error();
 int lpass_log_is_none();
+const char* lpass_log_level_string();
 void lpass_log(enum log_level level, char *fmt, ...);
 FILE *lpass_log_open();
+const char* lpass_short_fname(const char* fname);
+const char* lpass_log_bool_to_string(int b);
+void lpass_log_set_log_to_stderr();
 
-#define LOG0(level, fmt)      (lpass_log(level, "%s:%d:%s: " fmt, __FILE__, __LINE__, __func__))
-#define LOG(level, fmt, ...)  (lpass_log(level, "%s:%d:%s: " fmt, __FILE__, __LINE__, __func__, __VA_ARGS__))
+#define LOG0(level, fmt)			(lpass_log(level, "%s:%s:%d: " fmt, lpass_short_fname(__FILE__), __func__, __LINE__))
+#define LOG(level, fmt, ...)	(lpass_log(level, "%s:%s:%d: " fmt, lpass_short_fname(__FILE__), __func__, __LINE__, __VA_ARGS__))
 
-#define LOG_VERBOSE0(fmt)      if (lpass_log_is_verbose()) LOG0(LOG_LEVEL_VERBOSE, fmt)
+#define LOG_VERBOSE0(fmt)			 if (lpass_log_is_verbose()) LOG0(LOG_LEVEL_VERBOSE, fmt)
 #define LOG_VERBOSE(fmt, ...)  if (lpass_log_is_verbose()) LOG(LOG_LEVEL_VERBOSE, fmt, __VA_ARGS__)
 
-#define LOG_DEBUG0(fmt)      if (lpass_log_is_debug()) LOG0(LOG_LEVEL_DEBUG, fmt)
+#define LOG_DEBUG0(fmt)			 if (lpass_log_is_debug()) LOG0(LOG_LEVEL_DEBUG, fmt)
 #define LOG_DEBUG(fmt, ...)  if (lpass_log_is_debug()) LOG(LOG_LEVEL_DEBUG, fmt, __VA_ARGS__)
 
-#define LOG_INFO0(fmt)      if (lpass_log_is_info()) LOG0(LOG_LEVEL_INFO, fmt)
-#define LOG_INFO(fmt, ...)  if (lpass_log_is_info()) LOG(LOG_LEVEL_INFO, fmt, __VA_ARGS__)
+#define LOG_INFO0(fmt)			if (lpass_log_is_info()) LOG0(LOG_LEVEL_INFO, fmt)
+#define LOG_INFO(fmt, ...)	if (lpass_log_is_info()) LOG(LOG_LEVEL_INFO, fmt, __VA_ARGS__)
 
-#define LOG_WARNING0(fmt)      if (lpass_log_is_warning()) LOG0(LOG_LEVEL_WARNING, fmt)
+#define LOG_WARNING0(fmt)			 if (lpass_log_is_warning()) LOG0(LOG_LEVEL_WARNING, fmt)
 #define LOG_WARNING(fmt, ...)  if (lpass_log_is_warning()) LOG(LOG_LEVEL_WARNING, fmt, __VA_ARGS__)
 
-#define LOG_ERROR0(fmt)      if (lpass_log_is_error()) LOG0(LOG_LEVEL_ERROR, fmt)
+#define LOG_ERROR0(fmt)			 if (lpass_log_is_error()) LOG0(LOG_LEVEL_ERROR, fmt)
 #define LOG_ERROR(fmt, ...)  if (lpass_log_is_error()) LOG(LOG_LEVEL_ERROR, fmt, __VA_ARGS__)
 
 #endif

--- a/log.h
+++ b/log.h
@@ -11,16 +11,40 @@
  */
 enum log_level
 {
-	LOG_NONE = -1,
-	LOG_ERROR = 3,
-	LOG_WARNING = 4,
-	LOG_INFO = 6,
-	LOG_DEBUG = 7,
-	LOG_VERBOSE = 8,	/* _everything_ including CURL verbose logs */
+	LOG_LEVEL_NONE = -1,
+	LOG_LEVEL_ERROR = 3,
+	LOG_LEVEL_WARNING = 4,
+	LOG_LEVEL_INFO = 6,
+	LOG_LEVEL_DEBUG = 7,
+	LOG_LEVEL_VERBOSE = 8,	/* _everything_ including CURL verbose logs */
 };
 
 int lpass_log_level();
+int lpass_log_is_verbose();
+int lpass_log_is_debug();
+int lpass_log_is_info();
+int lpass_log_is_warning();
+int lpass_log_is_error();
+int lpass_log_is_none();
 void lpass_log(enum log_level level, char *fmt, ...);
 FILE *lpass_log_open();
+
+#define LOG0(level, fmt)      (lpass_log(level, "%s:%d " fmt, __FILE__, __LINE__))
+#define LOG(level, fmt, ...)  (lpass_log(level, "%s:%d " fmt, __FILE__, __LINE__, __VA_ARGS__))
+
+#define LOG_VERBOSE0(fmt)      if (lpass_log_is_verbose()) LOG0(LOG_LEVEL_VERBOSE, fmt)
+#define LOG_VERBOSE(fmt, ...)  if (lpass_log_is_verbose()) LOG(LOG_LEVEL_VERBOSE, fmt, __VA_ARGS__)
+
+#define LOG_DEBUG0(fmt)      if (lpass_log_is_debug()) LOG0(LOG_LEVEL_DEBUG, fmt)
+#define LOG_DEBUG(fmt, ...)  if (lpass_log_is_debug()) LOG(LOG_LEVEL_DEBUG, fmt, __VA_ARGS__)
+
+#define LOG_INFO0(fmt)      if (lpass_log_is_info()) LOG0(LOG_LEVEL_INFO, fmt)
+#define LOG_INFO(fmt, ...)  if (lpass_log_is_info()) LOG(LOG_LEVEL_INFO, fmt, __VA_ARGS__)
+
+#define LOG_WARNING0(fmt)      if (lpass_log_is_warning()) LOG0(LOG_LEVEL_WARNING, fmt)
+#define LOG_WARNING(fmt, ...)  if (lpass_log_is_warning()) LOG(LOG_LEVEL_WARNING, fmt, __VA_ARGS__)
+
+#define LOG_ERROR0(fmt)      if (lpass_log_is_error()) LOG0(LOG_LEVEL_ERROR, fmt)
+#define LOG_ERROR(fmt, ...)  if (lpass_log_is_error()) LOG(LOG_LEVEL_ERROR, fmt, __VA_ARGS__)
 
 #endif


### PR DESCRIPTION
I'd like to offer back some helper functions and macros.  This PR adds helpers like `lpass_log_is_verbose()` for testing the log levels, macros (`LOG_DEBUG()`) that are wrapped with a level check and automatically include file and line number information, and makes log initialization static.