### PR TITLE
fix valigrind identified memory leaks in cmd-ls.c

### DIFF
--- a/blob.c
+++ b/blob.c
@@ -62,6 +62,8 @@
 # endif
 #endif
 
+static void attach_free(struct attach *attach);
+
 struct app *account_to_app(const struct account *account)
 {
 	return container_of(account, struct app, account);
@@ -93,26 +95,38 @@ void field_free(struct field *field)
 void account_free_contents(struct account *account)
 {
 	struct field *field, *tmp;
+	struct attach *attach, *attach_tmp;
 
 	free(account->id);
 	free(account->name);
+	free(account->name_encrypted);
 	free(account->group);
+	free(account->group_encrypted);
 	free(account->fullname);
 	free(account->url);
 	free(account->username);
-	free(account->password);
-	free(account->note);
-	free(account->name_encrypted);
-	free(account->group_encrypted);
 	free(account->username_encrypted);
+	free(account->password);
 	free(account->password_encrypted);
+	free(account->note);
 	free(account->note_encrypted);
+	free(account->last_touch);
+	free(account->last_modified_gmt);
 	free(account->attachkey);
 	free(account->attachkey_encrypted);
 
 	list_for_each_entry_safe(field, tmp, &account->field_head, list) {
 		field_free(field);
 	}
+
+  // NB: do we need to free the share pointer?
+
+  list_for_each_entry_safe(attach, attach_tmp, &account->attach_head, list) {
+    attach_free(attach);
+  }
+
+  // NB: do we need to free list?
+  // NB: do we need to free match_list?
 }
 
 void app_free(struct app *app)

--- a/cmd-ls.c
+++ b/cmd-ls.c
@@ -373,11 +373,14 @@ int cmd_ls(int argc, char **argv)
 	session_free(session);
 	blob_free(blob);
 
+  /* NB: valgrind identified something related to account_array as a leak, though
+   * freeing the entries crashes the cli.
 	for (i=0; i < num_accounts; i++)
 	{
 		struct account *account = account_array[i];
     account_free(account);
   }
+  */
 
 	return 0;
 }

--- a/cmd-ls.c
+++ b/cmd-ls.c
@@ -372,5 +372,12 @@ int cmd_ls(int argc, char **argv)
 	free_node(root);
 	session_free(session);
 	blob_free(blob);
+
+	for (i=0; i < num_accounts; i++)
+	{
+		struct account *account = account_array[i];
+    account_free(account);
+  }
+
 	return 0;
 }

--- a/endpoints.c
+++ b/endpoints.c
@@ -248,6 +248,8 @@ void lastpass_log_access(enum blobsync sync, const struct session *session, unsi
 		http_post_add_params(&params, "sharedfolderid", account->share->id, NULL);
 
 	upload_queue_enqueue(sync, key, session, "loglogin.php", &params);
+
+  free(params.argv);
 }
 
 


### PR DESCRIPTION
cmake -DCMAKE_BUILD_TYPE=Debug .
make
valgrind --log-file=./valgrind.log --leak-check=full ./lpass ls --sync=now

Signed-off-by: Kyle Burton <kyle.burton@gmail.com>