### PR TITLE
Include pkg-config in Ubuntu dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ sudo apt-get install openssl libcurl3 libxml2 libssl-dev libxml2-dev libcurl4-op
 * For Ubuntu:
 
 ```
-sudo apt-get install openssl libcurl4-openssl-dev libxml2 libssl-dev libxml2-dev pinentry-curses xclip cmake build-essential
+sudo apt-get install openssl libcurl4-openssl-dev libxml2 libssl-dev libxml2-dev pinentry-curses xclip cmake build-essential pkg-config
 ```
 
 #### Gentoo


### PR DESCRIPTION
Running `cmake .` on Ubuntu 16.04 gives an error:

```
Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
```