### PR TITLE
Add SUN_LEN when not defined (termux)

### DIFF
--- a/agent.c
+++ b/agent.c
@@ -53,6 +53,11 @@
 #include <sys/param.h>
 #endif
 
+#if !defined(SUN_LEN)
+#define SUN_LEN(su) \
+        (sizeof(*(su)) - sizeof((su)->sun_path) + strlen((su)->sun_path))
+#endif
+
 #if !defined(__linux__) && !defined(__CYGWIN__)
 #define SOCKET_SEND_PID 1
 struct ucred {


### PR DESCRIPTION
I was trying to compile lastpass-cli for [termux](https://termux.com/) (a Linux distribution for non-rooted Android), and there was a single, easy-to-fix error: SUN_LEN is not defined on Android's `un.h`. I added the definition inside `agent.c` (where it is used), since it's a very simple macro.

There are however alternative implementations, like `sizeof( struct sockaddr_un )` (see this reference for more details: https://stackoverflow.com/a/2307539/154480). You may also prefer to see this defined elsewhere, etc. Let me know if you'd consider this pull request, and if I should make any changes to it.