### PR TITLE
pid_to_cmd: Use sysctl on FreeBSD, DragonFly and NetBSD.

### DIFF
--- a/process.c
+++ b/process.c
@@ -48,6 +48,9 @@
 #include <libproc.h>
 #include <sys/ptrace.h>
 #define USE_PTRACE
+#elif defined(__FreeBSD__) || defined(__DragonFly__) || defined(__NetBSD__)
+#include <sys/param.h>
+#include <sys/sysctl.h>
 #elif defined(__OpenBSD__)
 #include <sys/param.h>
 #include <sys/proc.h>
@@ -73,17 +76,11 @@ static void ptrace(__attribute__((unused)) int x,
 #endif
 
 
-#if defined(__linux__) || defined(__CYGWIN__) || defined(__NetBSD__)
-#define DEVPROC_NAME "exe"
-#elif defined(__FreeBSD__) || defined(__DragonFly__)
-#define DEVPROC_NAME "file"
-#endif
-
-#ifdef DEVPROC_NAME
+#if defined(__linux__) || defined(__CYGWIN__) || (defined(__NetBSD__) && !defined(KERN_PROC_PATHNAME))
 static int pid_to_cmd(pid_t pid, char *cmd, size_t cmd_size)
 {
 	_cleanup_free_ char *proc;
-	xasprintf(&proc, "/proc/%lu/" DEVPROC_NAME, (unsigned long)pid);
+	xasprintf(&proc, "/proc/%lu/exe", (unsigned long)pid);
 	return readlink(proc, cmd, cmd_size - 1);
 }
 #elif defined(__APPLE__) && defined(__MACH__)
@@ -92,6 +89,13 @@ static int pid_to_cmd(pid_t pid, char *cmd, size_t cmd_size)
 	int result;
 	result = proc_pidpath(pid, cmd, cmd_size);
 	return (result <= 0) ? -1 : 0;
+}
+#elif defined(__FreeBSD__) || defined(__DragonFly__) || defined(__NetBSD__)
+static int pid_to_cmd(pid_t pid, char *cmd, size_t cmd_size)
+{
+	int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, pid };
+
+	return sysctl(mib, 4, cmd, &cmd_size, NULL, 0);
 }
 #elif defined(__OpenBSD__)
 static int pid_to_cmd(pid_t pid, char *cmd, size_t cmd_size)


### PR DESCRIPTION
Replace use of /proc with sysctl KERN_PROC_PATHNAME on FreeBSD,
DragonFlyBSD (3.8+) and recent NetBSDs (8.0+).

As NetBSD 8 isn't out yet, the fallback to /proc is maintained.
DragonFlyBSD 3.8 is 3 years old and there seems little reason to make
the logic more complex for the sake of supporting older versions.

Signed-off-by: Thomas Hurst <tom@hur.st>