### PR TITLE
Updated Readme to reflect correct Arch Linux information

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,16 @@ Command line interface to [LastPass.com](https://lastpass.com/).
 
 ### Installing on Linux
 #### Arch
-* Binary packages are available in the [Arch User Repository (AUR)](https://aur.archlinux.org/packages.php?O=0&L=0&C=0&K=lastpass-cli). Information about installing packages from the AUR [can be found on the Arch wiki](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages).
+* A binary package is available from the community repository, use pacman to simple install lastpass-cli.
+* Can be build from source with the "lastpass-cli-git" *[Arch User Repository (AUR)](https://aur.archlinux.org/packages.php?O=0&L=0&C=0&K=lastpass-cli). 
+Information about installing packages from the AUR [can be found on the Arch wiki](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages).
+
+```
+# from community repository
+sudo pacman -S lastpass-cli
+# from AUR repository
+packer -S lastpass-cli-git
+```
 
 #### Fedora
 


### PR DESCRIPTION
There are two packages now available to install, one in the community repository and the other is AUR based which builds from source. 
Added correction in the Readme to reflect that