### PR TITLE
Fixes #1 and #318

### DIFF
--- a/cmd-show.c
+++ b/cmd-show.c
@@ -129,6 +129,7 @@ static void show_attachment(const struct session *session,
 	char opt;
 	char *ptext;
 	size_t len;
+	char *shareid = NULL;
 	unsigned char *bytes = NULL;
 	FILE *fp = stdout;
 
@@ -138,9 +139,12 @@ static void show_attachment(const struct session *session,
 	if (hex_to_bytes(account->attachkey, &key_bin))
 		die("Invalid attach key for account %s\n", account->name);
 
+	if (account->share != NULL)
+		shareid = account->share->id;
+
 	filename = attachment_filename(account, attach);
 
-	ret = lastpass_load_attachment(session, attach, &result);
+	ret = lastpass_load_attachment(session, shareid, attach, &result);
 	if (ret)
 		die("Could not load attachment %s\n", attach->id);
 

--- a/endpoints.c
+++ b/endpoints.c
@@ -461,6 +461,7 @@ int lastpass_upload(const struct session *session,
  * in *result should be freed by the caller.
  */
 int lastpass_load_attachment(const struct session *session,
+			     const char *shareid,
 			     struct attach *attach,
 			     char **result)
 {
@@ -469,9 +470,25 @@ int lastpass_load_attachment(const struct session *session,
 
 	*result = NULL;
 
-	reply = http_post_lastpass("show_website.php", session, NULL,
-				   "token", session->token,
-				   "getattach", attach->storagekey, NULL);
+	struct http_param_set params = {
+		.argv = NULL,
+		.n_alloced = 0
+	};
+
+	http_post_add_params(&params,
+			     "token", session->token,
+			     "getattach", attach->storagekey,
+			     NULL);
+
+	if (shareid) {
+		http_post_add_params(&params,
+				     "sharedfolderid", shareid,
+				     NULL);
+	}
+
+	reply = http_post_lastpass_param_set("getattach.php",
+					     session, NULL,
+					     &params);
 	if (!reply)
 		return -ENOENT;
 

--- a/endpoints.h
+++ b/endpoints.h
@@ -27,5 +27,5 @@ int lastpass_share_set_limits(const struct session *session, struct share *share
 int lastpass_pwchange_start(const struct session *session, const char *username, const char hash[KDF_HEX_LEN], struct pwchange_info *pwchange_info);
 int lastpass_pwchange_complete(const struct session *session, const char *username, const char *enc_username, const char new_hash[KDF_HEX_LEN], int new_iterations, struct pwchange_info *pwchange_info);
 int lastpass_upload(const struct session *session, struct list_head *accounts);
-int lastpass_load_attachment(const struct session *session, struct attach *attach, char **result);
+int lastpass_load_attachment(const struct session *session, const char *shareid, struct attach *attach, char **result);
 #endif


### PR DESCRIPTION
Load attachments from the correct endpoint. For shared attachments, include the shared folder id.