### PR TITLE
use-after-free bug in http.c

### DIFF
--- a/http.c
+++ b/http.c
@@ -310,8 +310,8 @@ char *http_post_lastpass_v_noexit(const char *server, const char *page, const st
 	ret = curl_easy_perform(curl);
 	unset_interrupt_detect();
 
-	curl_easy_cleanup(curl);
 	curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, http_code);
+	curl_easy_cleanup(curl);
 	*curl_ret = ret;
 
 	if (ret != CURLE_OK) {


### PR DESCRIPTION
OpenBSD has some nifty features for the memory allocator. One of these
features is 'use after free detection'. With this this feature enabled
lpass segfaults.

This segfault is explained by the order of curl_easy_cleanup and
curl_easy_getinfo in http.c: First a libcurl easy handle is ended, and
then it is used to gather some information.

Description of curl_easy_cleanup states that "This function must be the
last function to call for an easy session."

Signed-off-by: Björn Ketelaars <bjorn.ketelaars@hydroxide.nl>