### PR TITLE
Support VISUAL editor environment variable (Closes: github #337)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ lpass.exe
 certificate.h
 tags
 build
+test/.lpass

--- a/edit.c
+++ b/edit.c
@@ -526,9 +526,9 @@ int edit_account(struct session *session,
 		}
 		fclose(tmpfile);
 
-		xasprintf(&editcmd, "${EDITOR:-vi} '%s'", tmppath);
+		xasprintf(&editcmd, "${VISUAL:-${EDITOR:-vi}} '%s'", tmppath);
 		if (system(editcmd) < 0)
-			die_unlink_errno("system($EDITOR)", tmppath, tmpdir);
+			die_unlink_errno("system($VISUAL)", tmppath, tmpdir);
 
 		tmpfile = fopen(tmppath, "r");
 	} else


### PR DESCRIPTION
Takes preference over the EDITOR environment variable as per
https://en.wikibooks.org/wiki/Guide_to_Unix/Environment_Variables#VISUAL