### PR TITLE
generate: fix type for option parsing

### DIFF
--- a/cmd-generate.c
+++ b/cmd-generate.c
@@ -61,7 +61,7 @@ int cmd_generate(int argc, char **argv)
 		{"clip", no_argument, NULL, 'c'},
 		{0, 0, 0, 0}
 	};
-	char option;
+	int option;
 	int option_index;
 	char *username = NULL;
 	char *url = NULL;


### PR DESCRIPTION
char may or may not be signed depending on architecture. If char is
unsigned on a given architecture, then will the testing the return value
from getopt_long (which is int) always fail. This happened on some
architectures like ppc64le, aarch64 and s390x.

To fix this we use same type as getopt_long return value: int.

fixes #345

Signed-off-by: Natanael Copa <ncopa@alpinelinux.org>