### PR TITLE
Remove --with-doc instruction for Homebrew install

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,6 @@ brew update
 brew install lastpass-cli --with-pinentry
 ```
 
-Alternatively, if you want to install the documentation as well:
-
-```
-brew install lastpass-cli --with-pinentry --with-doc
-```
-
 #### With [MacPorts](https://www.macports.org/)
 * [Install MacPorts](https://www.macports.org/install.php), if necessary.
 * Update MacPorts' local ports tree:


### PR DESCRIPTION
Fixes #347

`brew install lastpass-cli` installs documentation by default [as of 1.1.0](https://github.com/Homebrew/homebrew-core/blob/382b72b92e0ee425f25d2c06e4005552918c7223/Formula/lastpass-cli.rb).