### PR TITLE
#314 Allow providing custom path to pinentry

### DIFF
--- a/lpass.1.txt
+++ b/lpass.1.txt
@@ -77,8 +77,11 @@ variable 'LPASS_AGENT_DISABLE' is set to 1, the agent will not be used.
 
 Password Entry
 ~~~~~~~~~~~~~~
-If available, the *pinentry* program, part of *gpg2*(1), may be used for inputting
-passwords if it is installed. If unavailable, or if the 'LPASS_DISABLE_PINENTRY'
+The *pinentry* program, part of *gpg2*(1), may be used for inputting
+passwords if it is installed. A custom path to the *pinentry* program can be
+provided by the 'LPASS_PINENTRY' environment variable.
+
+If *pinentry* program is unavailable, or if the 'LPASS_DISABLE_PINENTRY'
 environment variable is set to 1, passwords will be read from standard input and a
 prompt will be displayed on standard error.
 
@@ -279,6 +282,7 @@ in the section above:
 * 'LPASS_AUTO_SYNC_TIME'
 * 'LPASS_AGENT_TIMEOUT'
 * 'LPASS_AGENT_DISABLE'
+* 'LPASS_PINENTRY'
 * 'LPASS_DISABLE_PINENTRY'
 * 'LPASS_ASKPASS'
 * 'LPASS_CLIPBOARD_COMMAND'

--- a/password.c
+++ b/password.c
@@ -228,6 +228,8 @@ char *password_prompt(const char *prompt, const char *error, const char *descfmt
 	_cleanup_free_ char *password = NULL;
 	char *password_fallback;
 	char *askpass;
+	char *pinentry_fallback = "pinentry";
+	char *pinentry;
 	char *ret;
 	va_list params;
 	int devnull;
@@ -248,6 +250,11 @@ char *password_prompt(const char *prompt, const char *error, const char *descfmt
 		return password_fallback;
 	}
 
+	pinentry = getenv("LPASS_PINENTRY");
+	if (!pinentry) {
+		pinentry = pinentry_fallback;
+	}
+
 	if (pipe(write_fds) < 0 || pipe(read_fds) < 0)
 		die_errno("pipe");
 
@@ -266,7 +273,7 @@ char *password_prompt(const char *prompt, const char *error, const char *descfmt
 		close(read_fds[1]);
 		close(write_fds[0]);
 		close(write_fds[1]);
-		execlp("pinentry", "pinentry", NULL);
+		execlp(pinentry, pinentry, NULL);
 		_exit(76);
 	}
 	close(read_fds[1]);


### PR DESCRIPTION
My particular use case is to use a ncurses pinentry instead of gtk2 one which is linked from `/usr/bin/pinentry` by default in Archlinux.

Fixes #314