### PR TITLE
add show --quiet to print binary attachments to stdout

### DIFF
--- a/cmd.h
+++ b/cmd.h
@@ -81,7 +81,7 @@ int cmd_passwd(int argc, char **argv);
 #define cmd_passwd_usage "passwd"
 
 int cmd_show(int argc, char **argv);
-#define cmd_show_usage "show [--sync=auto|now|no] [--clip, -c] [--expand-multi, -x] [--all|--username|--password|--url|--notes|--field=FIELD|--id|--name|--attach=ATTACHID] [--basic-regexp, -G|--fixed-strings, -F] " color_usage " {UNIQUENAME|UNIQUEID}"
+#define cmd_show_usage "show [--sync=auto|now|no] [--clip, -c] [--quiet, -q] [--expand-multi, -x] [--all|--username|--password|--url|--notes|--field=FIELD|--id|--name|--attach=ATTACHID] [--basic-regexp, -G|--fixed-strings, -F] " color_usage " {UNIQUENAME|UNIQUEID}"
 
 int cmd_ls(int argc, char **argv);
 #define cmd_ls_usage "ls [--sync=auto|now|no] [--long, -l] [-m] [-u] " color_usage " [GROUP]"

--- a/lpass.1.txt
+++ b/lpass.1.txt
@@ -24,7 +24,7 @@ several subcommands:
  lpass *login* [--trust] [--plaintext-key [--force, -f]] [--color=auto|never|always] USERNAME
  lpass *logout* [--force, -f] [--color=auto|never|always]
  lpass *passwd*
- lpass *show* [--sync=auto|now|no] [--clip, -c] [--expand-multi, -x] [--all|--username|--password|--url|--notes|--field=FIELD|--id|--name|--attach=ATTACHID] [--basic-regexp, -G|--fixed-strings, -F] [--color=auto|never|always] {NAME|UNIQUEID}*
+ lpass *show* [--sync=auto|now|no] [--clip, -c] [--quiet, -q] [--expand-multi, -x] [--all|--username|--password|--url|--notes|--field=FIELD|--id|--name|--attach=ATTACHID] [--basic-regexp, -G|--fixed-strings, -F] [--color=auto|never|always] {NAME|UNIQUEID}*
  lpass *ls* [--sync=auto|now|no] [--long, -l] [-m] [-u] [--color=auto|never|always] [GROUP]
  lpass *mv* [--sync=auto|now|no] [--color=auto|never|always] {UNIQUENAME|UNIQUEID} GROUP
  lpass *add* [--sync=auto|now|no] [--non-interactive] {--name|--username, -u|--password, -p|--url|--notes|--field=FIELD|--note-type=NOTETYPE} [--color=auto|never|always] {NAME|UNIQUEID}
@@ -331,6 +331,10 @@ att-1426405543365295118-94690: travel-flight.pdf
 $ lpass show my-secure-note --attach att-1426405543365295118-94690
 "travel-flight.pdf" is a binary file, print it anyway (or save)?  [y/n/S] s
 Wrote 122864 bytes to "travel-flight.pdf"
+
+# Display secure note attachment to standard output
+$ lpass show my-secure-note --attach att-1426405543365295118-94690 --quiet
+[... binary data on stdout ...]
 
 # Add an account non-interactively by creating the proper template
 printf "Username: wizard97\nPassword: vJwhFfBBtn8hj4" | \


### PR DESCRIPTION
problem: trying to automate printing attachments to standard
output the program stops and asks for user input. To avoid
this behaviour I've implemented --quiet in the same way as
status so it just behaves as usual (printing to standard output)

documentation and --help have both been updated

Example without --quiet:

> **$ lpass show 1234123412341234 --attach=att-1234123412341234-1234**
> "file.dat" is a binary file, print it anyway (or save)?  [y/n/S] y
> this is file.dat

Example with --quiet:

> **$ lpass show 1234123412341234 --attach=att-1234123412341234-1234 --quiet**
> this is file.dat

The commit has now been signed off by me.