### PR TITLE
Export json format

### DIFF
--- a/cmd-export.c
+++ b/cmd-export.c
@@ -338,7 +338,7 @@ void print_json_field(const struct session *session,
 	JSON_OUTPUT_FIELD("last_modified_gmt", account->last_modified_gmt, is_last);
 	JSON_OUTPUT_FIELD_BOOL("attachpresent", account->attachpresent, is_last);
 
-	if (!strcmp(field_name, "attachments") && !list_empty (&account->attach_head)) {
+	if (!strcmp(field_name, "attachments")) {
 		printf ("      \"attachments\" : [\n");
 		list_for_each_entry(attach, &account->attach_head, list) {
 			print_json_base64_attachment (session, account, attach);

--- a/cmd-export.c
+++ b/cmd-export.c
@@ -46,6 +46,11 @@
 #include <unistd.h>
 #include <string.h>
 
+enum output_format {
+	OUTPUT_FORMAT_CSV,
+	OUTPUT_FORMAT_JSON
+};
+
 struct field_selection {
 	const char *name;
 	struct list_head list;
@@ -100,7 +105,7 @@ void print_csv_field(struct account *account, const char *field_name,
 	_cleanup_free_ char *share_group = NULL;
 	char *groupname = account->group;
 
-#define OUTPUT_FIELD(name, value, is_last) \
+#define CSV_OUTPUT_FIELD(name, value, is_last) \
 	do { \
 		if (!strcmp(field_name, name)) { \
 			print_csv_cell(value, is_last); \
@@ -108,23 +113,22 @@ void print_csv_field(struct account *account, const char *field_name,
 		} \
 	} while(0)
 
-	OUTPUT_FIELD("url", account->url, is_last);
-	OUTPUT_FIELD("username", account->username, is_last);
-	OUTPUT_FIELD("password", account->password, is_last);
-	OUTPUT_FIELD("extra", account->note, is_last);
-	OUTPUT_FIELD("name", account->name, is_last);
-	OUTPUT_FIELD("fav", bool_str(account->fav), is_last);
-	OUTPUT_FIELD("id", account->id, is_last);
-	OUTPUT_FIELD("group", account->group, is_last);
-	OUTPUT_FIELD("fullname", account->fullname, is_last);
-	OUTPUT_FIELD("last_touch", account->last_touch, is_last);
-	OUTPUT_FIELD("last_modified_gmt", account->last_modified_gmt, is_last);
-	OUTPUT_FIELD("attachpresent", bool_str(account->attachpresent), is_last);
+	CSV_OUTPUT_FIELD("url", account->url, is_last);
+	CSV_OUTPUT_FIELD("username", account->username, is_last);
+	CSV_OUTPUT_FIELD("password", account->password, is_last);
+	CSV_OUTPUT_FIELD("extra", account->note, is_last);
+	CSV_OUTPUT_FIELD("name", account->name, is_last);
+	CSV_OUTPUT_FIELD("fav", bool_str(account->fav), is_last);
+	CSV_OUTPUT_FIELD("id", account->id, is_last);
+	CSV_OUTPUT_FIELD("group", account->group, is_last);
+	CSV_OUTPUT_FIELD("fullname", account->fullname, is_last);
+	CSV_OUTPUT_FIELD("last_touch", account->last_touch, is_last);
+	CSV_OUTPUT_FIELD("last_modified_gmt", account->last_modified_gmt, is_last);
+	CSV_OUTPUT_FIELD("attachpresent", bool_str(account->attachpresent), is_last);
 
 	if (!strcmp(field_name, "grouping")) {
 		if (account->share) {
-			xasprintf(&share_group, "%s\\%s",
-				  account->share->name, account->group);
+			xasprintf(&share_group, "%s\\%s", account->share->name, account->group);
 
 			/* trim trailing backslash if no subfolder */
 			if (!strlen(account->group))
@@ -140,17 +144,207 @@ void print_csv_field(struct account *account, const char *field_name,
 	print_csv_cell("", is_last);
 }
 
+void print_csv_entries (struct list_head *account_head, struct list_head *field_list)
+{
+	struct field_selection *field_sel = NULL;
+	struct account *account = NULL;
+	struct field_selection *last_entry =
+		list_last_entry_or_null(field_list, struct field_selection, list);
+
+	list_for_each_entry(account, account_head, list) {
+		/* skip groups */
+		if (!strcmp(account->url, "http://group"))
+			continue;
+
+		list_for_each_entry(field_sel, field_list, list) {
+			print_csv_field(account, field_sel->name, field_sel == last_entry);
+		}
+	}
+}
+
+static void print_csv_header (struct list_head *field_list) {
+	struct field_selection *field_sel = NULL;
+	struct field_selection *last_entry =
+		list_last_entry_or_null(field_list, struct field_selection, list);
+
+	list_for_each_entry(field_sel, field_list, list) {
+		print_csv_cell(field_sel->name, field_sel == last_entry);
+	}
+}
+
+static void print_json_quoted_string(const char *str) {
+	const char *ptr = NULL;
+
+	putchar ('"');
+
+	for (ptr = str; *ptr; ptr++) {
+		/* escape some characters according to http://www.ietf.org/rfc/rfc4627.txt */
+		switch (*ptr) {
+			case '\b': putchar ('\\'); putchar ('b'); break;
+			case '\f': putchar ('\\'); putchar ('f'); break;
+			case '\n': putchar ('\\'); putchar ('n'); break;
+			case '\r': putchar ('\\'); putchar ('r'); break;
+			case '\t': putchar ('\\'); putchar ('t'); break;
+			case '\\': putchar ('\\'); putchar ('\\');	break;
+			case  '"': putchar ('\\'); putchar ('"');	break;
+			default:
+				if ((*ptr) < ' ') {
+					printf ("\\u%04x", *ptr);
+				}
+				else {
+					putchar (*ptr);
+				}
+				break;
+		}
+	}
+
+	putchar ('"');
+}
+
+static void print_json_account_name (struct account *account) {
+	_cleanup_free_ char *share_group = NULL;
+	_cleanup_free_ char *account_name = NULL;
+	char *groupname = account->group;
+
+	if (account->share) {
+		xasprintf(&share_group, "%s\\%s", account->share->name, account->group);
+
+		/* trim trailing backslash if no subfolder */
+		if (!strlen(account->group))
+			share_group[strlen(share_group)-1] = '\0';
+
+		groupname = share_group;
+	}
+
+	xasprintf(&account_name, "%s\\%s", groupname, account->name);
+	print_json_quoted_string (account_name);
+}
+
+void print_json_field(struct account *account, const char *field_name,
+		     bool is_last)
+{
+#define JSON_OUTPUT_FIELD(name, value, is_last) \
+	if (!strcmp(field_name, name)) { \
+		printf ("    "); \
+		print_json_quoted_string(name); \
+		putchar(':'); \
+		print_json_quoted_string(value); \
+		if (!is_last) putchar (','); \
+		putchar ('\n'); \
+		return; \
+	}
+
+	JSON_OUTPUT_FIELD("url", account->url, is_last);
+	JSON_OUTPUT_FIELD("username", account->username, is_last);
+	JSON_OUTPUT_FIELD("password", account->password, is_last);
+	JSON_OUTPUT_FIELD("extra", account->note, is_last);
+	JSON_OUTPUT_FIELD("name", account->name, is_last);
+	JSON_OUTPUT_FIELD("fav", bool_str(account->fav), is_last);
+	JSON_OUTPUT_FIELD("id", account->id, is_last);
+	JSON_OUTPUT_FIELD("group", account->group, is_last);
+	JSON_OUTPUT_FIELD("fullname", account->fullname, is_last);
+	JSON_OUTPUT_FIELD("last_touch", account->last_touch, is_last);
+	JSON_OUTPUT_FIELD("last_modified_gmt", account->last_modified_gmt, is_last);
+	JSON_OUTPUT_FIELD("attachpresent", bool_str(account->attachpresent), is_last);
+
+	_cleanup_free_ char *share_group = NULL;
+	char *groupname = account->group;
+
+	if (!strcmp(field_name, "grouping")) {
+		if (account->share) {
+			xasprintf(&share_group, "%s\\%s", account->share->name, account->group);
+
+			/* trim trailing backslash if no subfolder */
+			if (!strlen(account->group))
+				share_group[strlen(share_group)-1] = '\0';
+
+			groupname = share_group;
+		}
+		JSON_OUTPUT_FIELD ("grouping", groupname, is_last);
+		return;
+	}
+
+}
+
+void print_json_entries (struct list_head *account_head, struct list_head *field_list)
+{
+	struct account *last_account =
+		list_last_entry_or_null(account_head, struct account, list);
+	struct field_selection *last_entry =
+		list_last_entry_or_null(field_list, struct field_selection, list);
+	struct field_selection *field_sel = NULL;
+	struct account *account = NULL;
+
+	list_for_each_entry(account, account_head, list) {
+		/* skip groups */
+		if (!strcmp(account->url, "http://group"))
+			continue;
+
+		printf ("  ");
+		print_json_account_name (account);
+		printf (" : {\n");
+		list_for_each_entry(field_sel, field_list, list) {
+			print_json_field(account, field_sel->name, field_sel == last_entry);
+		}
+		printf ("  }%s\n", (account == last_account) ? "" : ",");
+	}
+}
+
+static void print_header (enum output_format format, struct list_head *field_list) {
+	switch (format) {
+		case OUTPUT_FORMAT_JSON:
+			printf ("{\n");
+			break;
+
+		case OUTPUT_FORMAT_CSV:
+		default:
+			print_csv_header (field_list);
+			break;
+	}
+}
+
+static void print_footer (enum output_format format) {
+	switch (format) {
+		case OUTPUT_FORMAT_JSON:
+			printf ("}\n");
+			break;
+
+		case OUTPUT_FORMAT_CSV:
+		default:
+			break;
+	}
+}
+
+void print_entries (enum output_format format,
+			struct list_head *account_head,
+			struct list_head *field_list)
+{
+	switch (format) {
+		case OUTPUT_FORMAT_JSON:
+			print_json_entries (account_head, field_list);
+			break;
+
+		case OUTPUT_FORMAT_CSV:
+		default:
+			print_csv_entries (account_head, field_list);
+			break;
+	}
+}
+
+
 int cmd_export(int argc, char **argv)
 {
 	static struct option long_options[] = {
 		{"sync", required_argument, NULL, 'S'},
 		{"color", required_argument, NULL, 'C'},
 		{"fields", required_argument, NULL, 'f'},
+		{"json", no_argument, NULL, 'j'},
 		{0, 0, 0, 0}
 	};
 	int option;
 	int option_index;
 	enum blobsync sync = BLOB_SYNC_AUTO;
+	enum output_format format = OUTPUT_FORMAT_CSV;
 	struct account *account;
 	const char *default_fields[] = {
 		"url", "username", "password", "extra",
@@ -170,6 +364,9 @@ int cmd_export(int argc, char **argv)
 				break;
 			case 'f':
 				parse_field_arg(optarg, &field_list);
+				break;
+			case 'j':
+				format = OUTPUT_FORMAT_JSON;
 				break;
 			case '?':
 			default:
@@ -204,25 +401,16 @@ int cmd_export(int argc, char **argv)
 		}
 	}
 
-	struct field_selection *last_entry =
-		list_last_entry_or_null(&field_list, struct field_selection, list);
+	print_header (format, &field_list);
+	print_entries (format, &blob->account_head, &field_list);
+	print_footer (format);
 
-	/* header */
-	list_for_each_entry(field_sel, &field_list, list) {
-		print_csv_cell(field_sel->name, field_sel == last_entry);
-	}
-
-	/* entries */
+	/* log access to all entries */
 	list_for_each_entry(account, &blob->account_head, list) {
-
 		/* skip groups */
 		if (!strcmp(account->url, "http://group"))
 			continue;
 
-		list_for_each_entry(field_sel, &field_list, list) {
-			print_csv_field(account, field_sel->name,
-					field_sel == last_entry);
-		}
 		lastpass_log_access(sync, session, key, account);
 	}
 

--- a/cmd.h
+++ b/cmd.h
@@ -108,7 +108,7 @@ int cmd_sync(int argc, char **argv);
 #define cmd_sync_usage "sync [--background, -b] " color_usage
 
 int cmd_export(int argc, char **argv);
-#define cmd_export_usage "export [--sync=auto|now|no] " color_usage " [--fields=FIELDLIST]"
+#define cmd_export_usage "export [--sync=auto|now|no] " color_usage " [--fields=FIELDLIST] [--json]"
 
 int cmd_share(int argc, char **argv);
 #define cmd_share_usage "share subcommand sharename ..."

--- a/lpass.1.txt
+++ b/lpass.1.txt
@@ -35,7 +35,7 @@ several subcommands:
  lpass *status* [--quiet, -q] [--color=auto|never|always]
  lpass *sync* [--background, -b] [--color=auto|never|always]
  lpass *import* [--sync=auto|now|no] [--keep-dupes] [FILENAME]
- lpass *export* [--sync=auto|now|no] [--color=auto|never|always] [--fields=FIELDLIST]
+ lpass *export* [--sync=auto|now|no] [--color=auto|never|always] [--fields=FIELDLIST] [--json]
  lpass *share* *userls* SHARE
  lpass *share* *useradd* [--read-only=[true|false]] [--hidden=[true|false]] [--admin=[true|false]] SHARE USERNAME
  lpass *share* *usermod* [--read-only=[true|false]] [--hidden=[true|false]] [--admin=[true|false]] SHARE USERNAME
@@ -189,15 +189,18 @@ will create a duplicate entry of the one specified, but with a different 'ID'.
 Backup
 ~~~~~~
 The 'export' subcommand will dump all account information including
-passwords to stdout (unencrypted) in CSV format.  The optional
-'--fields=FIELDLIST' argument may contain a comma-separated subset of the
-following fields:
+passwords to stdout (unencrypted) in CSV or JSON format if optional --json
+argument is passed. To store backups please use CSV since JSON imports are
+not supported yet.
+
+The optional '--fields=FIELDLIST' argument may contain a comma-separated
+subset of the following fields for both CSV and JSON:
 
   id, url, username, password, extra, name, fav, id, grouping, group,
   fullname, last_touch, last_modified_gmt, attachpresent
 
 The 'import' subcommand does the reverse: accounts from an unencrypted
-CSV file are uploaded to the server.
+CSV file are uploaded to the server (JSON not supported yet).
 
 It is recommended that such backups be encrypted at rest, for example by
 piping to and from gpg.

--- a/lpass.1.txt
+++ b/lpass.1.txt
@@ -199,6 +199,10 @@ subset of the following fields for both CSV and JSON:
   id, url, username, password, extra, name, fav, id, grouping, group,
   fullname, last_touch, last_modified_gmt, attachpresent
 
+JSON format also supports this field to export all attachments:
+
+  attachments
+
 The 'import' subcommand does the reverse: accounts from an unencrypted
 CSV file are uploaded to the server (JSON not supported yet).
 


### PR DESCRIPTION
Allow exporting everything as JSON while still support CSV.

$ lpass export --json
$ lpass export --json --fields=name,grouping,attachments

json format is more convenient in order to export passwords or attachements in a programmatic way to use them while creating builds or doing deployments.

The original CSV format is still the default, to preserve backwards compatibility.  The man page has been updated as well. All commits have been signed off.