### PR TITLE
Set action on lpass help preventing a fallthrough (fixes #386)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# EditorConfig is awesome: http://EditorConfig.org
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+indent_size = 4
+charset = utf-8

--- a/README.md
+++ b/README.md
@@ -60,13 +60,33 @@ sudo yum install openssl libcurl libxml2 pinentry xclip openssl-devel libxml2-de
 * For Debian:
 
 ```
-sudo apt-get install openssl libcurl3 libxml2 libssl-dev libxml2-dev libcurl4-openssl-dev pinentry-curses xclip build-essential
+sudo apt install --no-install-recommends \
+  build-essential \
+  cmake \
+  libcurl3  \
+  libcurl4-openssl-dev  \
+  libssl-dev  \
+  libxml2  \
+  libxml2-dev  \
+  openssl  \
+  pinentry-curses \
+  pkg-config  \
+  xclip
 ```
 
 * For Ubuntu:
 
 ```
-sudo apt-get install openssl libcurl4-openssl-dev libxml2 libssl-dev libxml2-dev pinentry-curses xclip cmake build-essential pkg-config
+sudo apt install --no-install-recommends \
+  cmake \
+  libcurl4-openssl-dev \
+  libssl-dev \
+  libxml2 \
+  libxml2-dev \
+  openssl \
+  pinentry-curses \
+  pkg-config \
+  xclip
 ```
 
 #### Gentoo

--- a/lpass.c
+++ b/lpass.c
@@ -102,6 +102,8 @@ static int global_options(int argc, char *argv[])
 			case 'h':
 				version();
 				printf("\n");
+				help();
+				return 0;
 			case '?':
 				help();
 				return option == 'h';


### PR DESCRIPTION
Reordered the Ubuntu and Debian section.
Use apt instead of apt-get: https://itsfoss.com/apt-vs-apt-get-difference/

Signed-off-by: Wesley Schwengle <wesley@schwengle.net>