### PR TITLE
Add Dockerfile to create a clean build environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+/build/
+/test/.lpass

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,0 +1,36 @@
+FROM debian:testing-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN mkdir -p /tmp/build
+WORKDIR /tmp/build
+COPY . /tmp/build/
+
+RUN apt-get update \
+	&& apt-get --no-install-recommends -yqq install \
+		bash-completion \
+		build-essential \
+		cmake \
+		libcurl3  \
+		libcurl4-openssl-dev  \
+		# We install libssl1.0-dev because.. warnings otherwise
+		#libssl-dev  \
+		libssl1.0-dev \
+		libxml2  \
+		libxml2-dev  \
+		openssl  \
+		pkg-config \
+		ca-certificates \
+		xclip \
+	&& make \
+	&& make test \
+	&& make install \
+	&& apt-get autoremove --purge -yqq \
+		bash-completion \
+		libcurl4-openssl-dev  \
+		libssl1.0-dev \
+		#libssl-dev  \
+		libxml2-dev  \
+		pkg-config \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/* /var/cache/apt/* /tmp/build

--- a/contrib/Dockerfile.dev
+++ b/contrib/Dockerfile.dev
@@ -1,0 +1,29 @@
+FROM debian:testing-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN mkdir -p /tmp/build
+WORKDIR /tmp/build
+
+RUN apt-get update \
+	&& apt-get --no-install-recommends -y install \
+		bash-completion \
+		build-essential \
+		cmake \
+		libcurl3  \
+		libcurl4-openssl-dev  \
+		# We install libssl1.0-dev because.. warnings otherwise
+		#libssl-dev  \
+		libssl1.0-dev \
+		libxml2  \
+		libxml2-dev  \
+		openssl  \
+		pkg-config \
+		ca-certificates \
+		xclip
+
+COPY . /tmp/build/
+
+RUN make \
+	&& make test \
+	&& make install


### PR DESCRIPTION
There are two Dockerfiles: 1) Dockerfile and 2) Dockerfile.dev

The Dockerfile is the one which has the smallest image because
everything is done in 1 RUN statement.

The Dockerfile.dev is the one that may be easier for a developer. It
caches the apt-get install phase so you don't need to rebuild everything
from scratch if you are testing your changes. And it doesn't delete the
build artifacts so you can hop into the container and see what is left
behind.

The next step would be to create a Debian/Ubuntu package based of this
Docker image. I'll leave that as a TODO for now :)

Signed-off-by: Wesley Schwengle <wesley@schwengle.net>