### PR TITLE
Revert "pins: remove GlobalSign R1/R3 pins"

### DIFF
--- a/pins.h
+++ b/pins.h
@@ -5,8 +5,12 @@ const char *PK_PINS[] = {
 	"HXXQgxueCIU5TTLHob/bPbwcKOKw6DkfsTWYHbxbqTY=",
 	/* current lastpass.eu primary (AddTrust) */
 	"lCppFqbkrlJ3EcVFAkeip0+44VaoJUymbnOaEUk7tEU=",
+	/* future lastpass root CA (GlobalSign R1) */
+	"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=",
 	/* future lastpass root CA (GlobalSign R2) */
 	"iie1VXtL7HzAMF+/PVPR9xzT80kQxdZeJ+zduCB3uj0=",
+	/* future lastpass root CA (GlobalSign R3) */
+	"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=",
 	/* future lastpass.com primary (leaf) */
 	"0hkr5YW/WE6Nq5hNTcApxpuaiwlwy5HUFiOt3Qd9VBc=",
 	/* future lastpass.com backup (leaf) */


### PR DESCRIPTION
This reverts commit 46e2a0fb488f4ed7fd8cc3f1c5b64ca009abc5ba.

LP just got a new R3 cert and it broke the world; add back in R1/R3 so that lastpass-cli will start working again.  Hopefully the certificate issue can also be resolved on the server so that all existing clients aren't bricked.