### PR TITLE
Running 'make test' fails on OpenBSD.

### DIFF
--- a/config.c
+++ b/config.c
@@ -175,7 +175,7 @@ enum config_type config_path_type(const char *name)
 	}
 
 	/* lock files are runtime */
-	if (strlen(name) >= 5 && !strcmp(name-5, ".lock")) {
+	if (strlen(name) >= 5 && !strcmp(name + strlen(name) - 5, ".lock")) {
 		return CONFIG_RUNTIME;
 	}
 


### PR DESCRIPTION
Running 'make test' on OpenBSD results in sporadicaly, random tests
failing. Cause is always the same; a segmentation fault in lpass-test.
Output of a backtrace:

```
(gdb) bt
#0  strcmp () at /usr/src/lib/libc/arch/amd64/string/strcmp.S:19
#1  0x00000ea544013432 in config_path_type (name=0xea82c7ca000 "upload-queue/15266634470001") at /tmp/ports/pobj/lastpass-cli-1.3.1/lastpass-cli-1.3.1/config.c:178
#2  0x00000ea5440134e5 in config_path (name=0xea82c7ca000 "upload-queue/15266634470001") at /tmp/ports/pobj/lastpass-cli-1.3.1/lastpass-cli-1.3.1/config.c:195
#3  0x00000ea544013891 in config_exists (name=0xea82c7ca000 "upload-queue/15266634470001") at /tmp/ports/pobj/lastpass-cli-1.3.1/lastpass-cli-1.3.1/config.c:218
#4  0x00000ea54402189c in upload_queue_write_entry (
    entry=0xea7f3b3b800 "show_website.php\nextjs\n1\ntoken\nabcd\nmethod\ncli\nname\n!fJpRFXdBBSG+gDij1lHw6w==|+tGkaSkIoUbyhAQifugbxtKpS3GYoj1xDa0Vc+s5GIw=\ngrouping\n\npwprotect\noff\naid\n0\nurl\n687474703a2f2f736e\nusername\n\npassword\n\nextr"..., key=0x7f7ffffedee0 "S±íؽQóã\207ø_\223m1ÓÀE]\t2r\201=y_©\2320\033â\217!Tßþÿ\177\177")
    at /tmp/ports/pobj/lastpass-cli-1.3.1/lastpass-cli-1.3.1/upload-queue.c:90
#5  0x00000ea5440217d4 in upload_queue_enqueue (sync=BLOB_SYNC_NO, key=0x7f7ffffedee0 "S±íؽQóã\207ø_\223m1ÓÀE]\t2r\201=y_©\2320\033â\217!Tßþÿ\177\177",
    session=0xea788620bc0, page=0xea54412c21c "show_website.php", params=0x7f7ffffedcd0) at /tmp/ports/pobj/lastpass-cli-1.3.1/lastpass-cli-1.3.1/upload-queue.c:435
#6  0x00000ea544019ac1 in lastpass_update_account (sync=BLOB_SYNC_NO, key=0x7f7ffffedee0 "S±íؽQóã\207ø_\223m1ÓÀE]\t2r\201=y_©\2320\033â\217!Tßþÿ\177\177",
    session=0xea788620bc0, account=0xea7ab15f100, blob=0xea759c16880) at /tmp/ports/pobj/lastpass-cli-1.3.1/lastpass-cli-1.3.1/endpoints.c:225
#7  0x00000ea544014ee6 in edit_account (session=0xea788620bc0, blob=0xea759c16880, sync=BLOB_SYNC_NO, editable=0xea7ab15f100, choice=EDIT_FIELD,
    field=0xea7cd5b2e10 "Public Key", non_interactive=true, key=0x7f7ffffedee0 "S±íؽQóã\207ø_\223m1ÓÀE]\t2r\201=y_©\2320\033â\217!Tßþÿ\177\177")
    at /tmp/ports/pobj/lastpass-cli-1.3.1/lastpass-cli-1.3.1/edit.c:597
#8  0x00000ea54400a067 in cmd_edit (argc=5, argv=0x7f7ffffedfe0) at /tmp/ports/pobj/lastpass-cli-1.3.1/lastpass-cli-1.3.1/cmd-edit.c:139
#9  0x00000ea54401df2d in process_command (argc=5, argv=0x7f7ffffedfe0) at /tmp/ports/pobj/lastpass-cli-1.3.1/lastpass-cli-1.3.1/lpass.c:164
#10 0x00000ea54401dd22 in main (argc=6, argv=0x7f7ffffedfd8) at /tmp/ports/pobj/lastpass-cli-1.3.1/lastpass-cli-1.3.1/lpass.c:205
Current language:  auto; currently asm
```

Frame 1 shows something interesting:

```
(gdb) frame 1
#1  0x00000ea544013432 in config_path_type (name=0xea82c7ca000 "upload-queue/15266634470001") at /tmp/ports/pobj/lastpass-cli-1.3.1/lastpass-cli-1.3.1/config.c:178
178		if (strlen(name) >= 5 && !strcmp(name-5, ".lock")) {
Current language:  auto; currently minimal
```

`strcmp(name-5, ".lock")` isn't right, and most likely should read
something like `strcmp(name + strlen(name) - 5, ".lock")`.

Diff has been tested successfully on OpenBSD, 'make test' runs
successfully, and lpass works as advertised.

Signed-off-by: Björn Ketelaars <bjorn.ketelaars@hydroxide.nl>