### PR TITLE
Update dependencies for Debian stable/testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,38 +54,43 @@ sudo yum install openssl libcurl libxml2 pinentry xclip openssl-devel libxml2-de
 
 
 #### Debian/Ubuntu
+
 * Install the needed build dependencies, and then follow instructions in
   the 'Building' section.
 
-* For Debian:
+* For Debian (stable/oldstable) and Ubuntu < 18.04
 
 ```
-sudo apt install --no-install-recommends \
+apt-get --no-install-recommends -yqq install \
+  bash-completion \
   build-essential \
   cmake \
   libcurl3  \
-  libcurl4-openssl-dev  \
-  libssl-dev  \
-  libxml2  \
+  libcurl3-openssl-dev  \
+  libssl1.0 \
+  libssl1.0-dev \
+  libxml2 \
   libxml2-dev  \
-  openssl  \
-  pinentry-curses \
-  pkg-config  \
+  pkg-config \
+  ca-certificates \
   xclip
 ```
 
-* For Ubuntu:
+* For Debian (testing/experimental) and Ubuntu >= 18.04
 
 ```
-sudo apt install --no-install-recommends \
+apt-get --no-install-recommends -yqq install \
+  bash-completion \
+  build-essential \
   cmake \
-  libcurl4-openssl-dev \
-  libssl-dev \
+  libcurl4  \
+  libcurl4-openssl-dev  \
+  libssl-dev  \
   libxml2 \
-  libxml2-dev \
-  openssl \
-  pinentry-curses \
+  libxml2-dev  \
+  libssl1.1 \
   pkg-config \
+  ca-certificates \
   xclip
 ```
 

--- a/contrib/Dockerfile.Debian-stable
+++ b/contrib/Dockerfile.Debian-stable
@@ -1,4 +1,4 @@
-FROM debian:testing-slim as build
+FROM debian:stable-slim as build
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -11,13 +11,13 @@ RUN apt-get update \
 		# Build dependencies
 		build-essential \
 		cmake \
-		libcurl4-openssl-dev  \
-		libssl-dev  \
+		libcurl3-openssl-dev  \
+		libssl1.0-dev  \
 		libxml2-dev  \
 		pkg-config \
 		# Run time dependencies
-		libcurl4  \
-		libssl1.1 \
+		libcurl3  \
+		libssl1.0 \
 		libxml2 \
 		# Optionals handy for testing within the container
 		bash-completion \
@@ -28,8 +28,8 @@ RUN apt-get update \
 	&& make install \
 	&& apt-get autoremove --purge -yqq \
 		bash-completion \
-		libcurl4-openssl-dev  \
-		libssl-dev  \
+		libcurl3-openssl-dev  \
+		libssl1.0-dev  \
 		libxml2-dev  \
 		pkg-config \
 	&& apt-get clean \

--- a/contrib/Dockerfile.dev
+++ b/contrib/Dockerfile.dev
@@ -7,18 +7,19 @@ WORKDIR /tmp/build
 
 RUN apt-get update \
 	&& apt-get --no-install-recommends -y install \
-		bash-completion \
+		# Build dependencies
 		build-essential \
 		cmake \
-		libcurl3  \
 		libcurl4-openssl-dev  \
-		# We install libssl1.0-dev because.. warnings otherwise
-		#libssl-dev  \
-		libssl1.0-dev \
-		libxml2  \
+		libssl-dev  \
 		libxml2-dev  \
-		openssl  \
 		pkg-config \
+		# Run time dependencies
+		libssl1.1 \
+		libcurl4  \
+		libxml2 \
+		# Optionals handy for testing within the container
+		bash-completion \
 		ca-certificates \
 		xclip
 


### PR DESCRIPTION
I've also updated the README.md to reflect some changes for Ubuntu 18.04
as these are now the same as for Debian testing.

Closes: (GH #415)