### PR TITLE
Added an error message for not having a CSV header on import

### DIFF
--- a/cmd-import.c
+++ b/cmd-import.c
@@ -263,8 +263,10 @@ static int csv_parse_accounts(FILE *fp, struct list_head *account_list,
 	if (url_index == -1 && username_index == -1 &&
 	    password_index == -1 && extra_index == -1 &&
 	    name_index == -1 && grouping_index == -1 &&
-	    fav_index == -1)
+	    fav_index == -1) {
+		die("Could not read the CSV header at the first line of the input file");
 		return 0;
+	}
 
 	first = record;
 	list_for_each_entry(record, &items, list) {


### PR DESCRIPTION
I was trying to import one record that I had exported.  I didn't know I had to have a CSV header and I had to look at the code to figure out why it wasn't working.