### PR TITLE
Don't die if making config directory fails

### DIFF
--- a/config.c
+++ b/config.c
@@ -154,8 +154,7 @@ char *config_path_for_type(enum config_type type, const char *name)
 	ret = stat(config, &sbuf);
 	if ((ret == -1 && errno == ENOENT) || !S_ISDIR(sbuf.st_mode)) {
 		unlink(config);
-		if (mkdir(config, 0700) < 0)
-			die_errno("mkdir(%s)", config);
+		mkdir(config, 0700);
 	} else if (ret == -1)
 		die_errno("stat(%s)", config);
 


### PR DESCRIPTION
To keep my config directories clear, I don't allow them to be written to. For the case of lastpass-cli, it's perfectly possible in theory to use the program without a config directory. However, it isn't possible in practice because the program tries to create a config directory just to try to read from it, and it will die if it can't.

I don't think there's a lot to be gained from this — if it does need to write something to the configuration, it'll fail later anyway, and if it doesn't, then it doesn't matter whether the directory exists and the program should just carry on running.