### PR TITLE
Pinentry is a dependency: option doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ brew update
 * Install the lastpass-cli formula:
 
 ```
-brew install lastpass-cli --with-pinentry
+brew install lastpass-cli
 ```
 
 #### With [MacPorts](https://www.macports.org/)


### PR DESCRIPTION
At some point, pinentry was added to the list of required dependencies and the switch `--with-pinentry` was removed.