### PR TITLE
usage: use basename(argv[0])

### DIFF
--- a/lpass.c
+++ b/lpass.c
@@ -81,7 +81,7 @@ static void help(void)
 	terminal_printf("Usage:\n");
 	printf("  %s {--help|--version}\n", ARGV[0]);
 	for (size_t i = 0; i < ARRAY_SIZE(commands); ++i)
-		printf("  %s %s\n", ARGV[0], commands[i].usage);
+		printf("  %s %s\n", basename(ARGV[0]), commands[i].usage);
 }
 
 static int global_options(int argc, char *argv[])


### PR DESCRIPTION
Fixes this potential ugliness in some setups:

before
------

```
  Usage:
	/run/current-system/sw/bin/lpass {--help|--version}
	/run/current-system/sw/bin/lpass login ....
```

after
-----

```
  Usage:
	lpass {--help|--version}
	lpass login ....
```

Signed-off-by: William Casarin <jb55@jb55.com>