### PR TITLE
readme: home-brew formula doesn’t have `--with-pinentry` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ brew update
 * Install the lastpass-cli formula:
 
 ```
-brew install lastpass-cli --with-pinentry
+brew install lastpass-cli
 ```
 
 #### With [MacPorts](https://www.macports.org/)


### PR DESCRIPTION
The homebrew formula doesn't appear to have the option `--with-pinentry`, when I tried to install just now it reported the error:

```
thomas$ brew install lastpass-cli --with-pinentry
...
Error: invalid option: --with-pinentry
```
Is there a problem installing without this option? If not, I've updated the `README.md` accordingly.
