### PR TITLE
Include `libgen.h` for BSD builds

### DIFF
--- a/lpass.c
+++ b/lpass.c
@@ -46,6 +46,10 @@
 #include <getopt.h>
 #include <unistd.h>
 
+#if (defined(__APPLE__) && defined(__MACH__)) || defined(__FreeBSD__) || defined(__DragonFly__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#include <libgen.h>
+#endif
+
 #define CMD(name) { #name, cmd_##name##_usage, cmd_##name }
 static struct {
 	const char *name;


### PR DESCRIPTION
Under Linux/glibc one of two implementations of `basename` can be selected, the GNU one provided by:

    #define _GNU_SOURCE
    #include <string.h>

and the POSIX one by:

    #include <libgen.h>

However, BSDs only have the POSIX implementation, so conditionally include the header if BSD related definitions exist.

This fixes segfaults when displaying usage (`lpass --help`) under (at least) macOS and OpenBSD.