### PR TITLE
Remove memory leak in `config_path_for_type`

### DIFF
--- a/config.c
+++ b/config.c
@@ -163,7 +163,7 @@ char *config_path_for_type(enum config_type type, const char *name)
 	_cleanup_free_ char *dir_path = xstrdup(config);
 	char *saveptr = NULL;
 	for (char *token = strtok_r(buffer, "/", &saveptr); token && saveptr && strlen(saveptr) > 0; token = strtok_r(NULL, "/", &saveptr)) {
-		xasprintf(&dir_path, "%s/%s", dir_path, token);
+		xstrappendf(&dir_path, "/%s", token);
 
 		ret = stat(dir_path, &sbuf);
 		if ((ret == -1 && errno == ENOENT) || !S_ISDIR(sbuf.st_mode)) {


### PR DESCRIPTION
Replace repeated calls to `xasprintf` with calls to `xstrappendf`,
thus not repeatedly reallocating memory, only one instance of
which will be freed.

Signed-off-by: Tom Sullivan <tom@msbit.com.au>