### PR TITLE
Link against Brew CURL under macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,10 @@ if((APPLE) AND (NOT DEFINED OPENSSL_ROOT_DIR))
   set(OPENSSL_ROOT_DIR "/usr/local/opt/openssl")
 endif()
 
+if((APPLE))
+  set(ENV{PKG_CONFIG_PATH} "/usr/local/opt/curl/lib/pkgconfig")
+endif()
+
 find_package(LibXml2 REQUIRED)
 include_directories(${LIBXML2_INCLUDE_DIR})
 


### PR DESCRIPTION
If building on macOS, add the appropriate PKG_CONFIG_PATH to the
environment to hint to the `FindCURL` module to look for that one
first.

Fixes #427

Signed-off-by: Tom Sullivan <tom@msbit.com.au>