### PR TITLE
Force IPv4 for every curl call made to lastpass API servers

### DIFF
--- a/http.c
+++ b/http.c
@@ -278,6 +278,11 @@ char *http_post_lastpass_v_noexit(const char *server, const char *page, const st
 	curl_easy_setopt(curl, CURLOPT_URL, url);
 	curl_easy_setopt(curl, CURLOPT_USERAGENT, LASTPASS_CLI_USERAGENT);
 
+	/* TODO: Make this optional via either env vars and/or an option for
+	 *       lpass -4 or lpass -6
+	 */
+	curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+
 	if (lpass_log_level() >= LOG_VERBOSE) {
 		logstream = lpass_log_open();
 		if (logstream) {


### PR DESCRIPTION
Users with IPv6 enabled report slowness due to IPv6. The default of Curl
is to look at both IPv6 and IPv4. This quickfix makes it possible for
users to not experience these issues. We may need to do this differently
by enabling lpass -4 to force IPv4 and -6 for v6.

Fixes: #440, #475
Signed-off-by: Wesley Schwengle <wesley@schwengle.net>