### PR TITLE
make: don't require using make, as it is a compat wrapper for cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ include_directories(${CURL_INCLUDE_DIR})
 
 set(PROJECT_NAME lpass)
 
-file(GLOB PROJECT_HEADERS *.h)
+file(GLOB PROJECT_HEADERS *.h version.h)
 file(GLOB PROJECT_SOURCES *.c)
 
 set(PROJECT_DEFINITIONS "_GNU_SOURCE")
@@ -60,6 +60,9 @@ set(PROJECT_FLAGS "-std=gnu99 -pedantic -Wall -Wextra -Wno-language-extension-to
 if(APPLE)
   set(PROJECT_FLAGS "${PROJECT_FLAGS} -Wno-deprecated-declarations")
 endif()
+
+execute_process(COMMAND ./LASTPASS-VERSION-GEN
+	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 # Main lpass executable
 add_executable(${PROJECT_NAME} ${PROJECT_HEADERS} ${PROJECT_SOURCES})

--- a/LASTPASS-VERSION-GEN
+++ b/LASTPASS-VERSION-GEN
@@ -33,7 +33,7 @@ VN=$(expr "$VN" : v*'\(.*\)')
 
 if test -r $LPVF
 then
-	VC=$(sed -e 's/^LASTPASS_VERSION = //' <$LPVF)
+	VC=$(sed -ne 's/^#define LASTPASS_CLI_VERSION "\(.*\)"/\1/p' <$LPVF)
 else
 	VC=unset
 fi


### PR DESCRIPTION
Running part of the build process in the toplevel Makefile means that users are forbidden to use cmake directly in order to get more control over the cmake arguments, and are also forbidden to use alternative cmake backends without having the Make program installed.

It also causes unpredictable issues that must be worked around by every downstream consumer, when the established cmake build process that is supposed to work, aborts with:

/build/lastpass-cli-git/src/lastpass-cli/blob.c:42:10: fatal error: version.h: No such file or directory
 #include "version.h"
          ^~~~~~~~~~~
compilation terminated.

Fixes https://github.com/eli-schwartz/pkgbuilds/pull/12

...

Also even using make as a compat wrapper is broken as it recompiles version.h on every single run.