### PR TITLE
Decrease the time for the cli app to do things

### DIFF
--- a/blob.c
+++ b/blob.c
@@ -910,15 +910,19 @@ static struct blob *blob_get_latest(struct session *session, const unsigned char
 	local = local_blob(key, &session->private_key);
 	if (!local)
 		return lastpass_get_blob(session, key);
+
 	remote_version = lastpass_get_blob_version(session, key);
+
 	if (remote_version == 0) {
 		blob_free(local);
 		return NULL;
 	}
-	if (local->version < remote_version || (local->local_version && local->version == remote_version)) {
+
+	if (remote_version > local->version) {
 		blob_free(local);
 		return lastpass_get_blob(session, key);
 	}
+
 	config_touch("blob");
 	return local;
 }


### PR DESCRIPTION
When the local blob version and the remote version are the same skip
downloading a new blob and just continue with the current blob.  This
could potentially shave 300ms (or more, I've seen close to 2 seconds in
my browser) when the blob hasn't been updated on the remote side.

There is still a small performance hit on `login_check.php` but I cannot
think of logical ways why we would increase the timeout, the 5 seconds
that is place now make sense to me as you want to display things. Maybe
there should be a post action on any command that has `--sync=auto` so
subsequent calls have a blob in sync and would cause slowness of the CLI
app.

Fixes: #475
Signed-off-by: Wesley Schwengle <wesley@schwengle.net>