### PR TITLE
Be able to run cmake with cmake 3.7 and less

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
-IF (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} VERSION_GREATER_EQUAL 3.1)
-  cmake_minimum_required(VERSION 3.1)
-ELSE()
+IF (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} VERSION_LESS 3.1)
   set(CMAKE_LEGACY_CYGWIN_WIN32 0) # Remove when CMake > 2.8.4 is required
   cmake_minimum_required(VERSION 2.8)
+ELSE()
+  cmake_minimum_required(VERSION 3.1)
 ENDIF()
 
 project(lpass)


### PR DESCRIPTION
The CMakelist.txt uses VERSION_GREATER_EQUAL which isn't supported
until CMake 3.7. Use VERSION_LESS (which is around in 3.02) instead.

Fixes: #492
Signed-off-by: Wesley Schwengle <wesley@schwengle.net>