### PR TITLE
Remove version generation from Makefile

### DIFF
--- a/LASTPASS-VERSION-GEN
+++ b/LASTPASS-VERSION-GEN
@@ -39,7 +39,6 @@ else
 fi
 test "$VN" = "$VC" || {
 	echo >&2 "LASTPASS_CLI_VERSION  =$VN"
-	echo >&2 "LASTPASS_CLI_USERAGENT = $VN"
 	echo "#define LASTPASS_CLI_VERSION \"$VN\"" >$LPVF
 	echo "#define LASTPASS_CLI_USERAGENT \"LastPass-CLI/\" LASTPASS_CLI_VERSION" >>$LPVF
 }

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,6 @@ uninstall: $(CMAKEMAKE)
 	$(MAKE) -C $(BUILDDIR) uninstall
 
 $(CMAKEMAKE):
-	./LASTPASS-VERSION-GEN && mkdir -p $(BUILDDIR) && cd $(BUILDDIR) && cmake $(CMAKEOPTS) ..
+	mkdir -p $(BUILDDIR) && cd $(BUILDDIR) && cmake $(CMAKEOPTS) ..
 
 .PHONY: all doc-man clean $(CMAKEMAKE)


### PR DESCRIPTION
Since the cmake takes care of this we don't need to have it in the
Makefile anymore

Signed-off-by: Wesley Schwengle <wesley@schwengle.net>