### PR TITLE
Fix bug where logout requires login

### DIFF
--- a/cmd-logout.c
+++ b/cmd-logout.c
@@ -74,18 +74,18 @@ int cmd_logout(int argc, char **argv)
 	if (optind < argc)
 		die_usage(cmd_logout_usage);
 
-	if (!config_exists("verify"))
-		die("Not currently logged in.");
-
 	if (!force && !ask_yes_no(true, "Are you sure you would like to log out?")) {
 		terminal_printf(TERMINAL_FG_YELLOW TERMINAL_BOLD "Log out" TERMINAL_RESET ": aborted.\n");
 		return 1;
 	}
 
-	init_all(0, key, &session, NULL);
+	if (agent_ask(key)) {
+		init_all(0, key, &session, NULL);
+		lastpass_logout(session);
+	}
 
 	session_kill();
-	lastpass_logout(session);
+
 	terminal_printf(TERMINAL_FG_YELLOW TERMINAL_BOLD "Log out" TERMINAL_RESET ": complete.\n");
 	return 0;
 }

--- a/session.c
+++ b/session.c
@@ -101,8 +101,11 @@ struct session *session_load(unsigned const char key[KDF_HASH_LEN])
 
 void session_kill()
 {
-	if (!config_unlink("verify") || !config_unlink("username") || !config_unlink("session_sessionid") || !config_unlink("iterations"))
-		die_errno("could not log out.");
+	config_unlink("verify");
+	config_unlink("username");
+	config_unlink("session_sessionid");
+	config_unlink("iterations");
+
 	config_unlink("blob");
 	config_unlink("session_token");
 	config_unlink("session_uid");


### PR DESCRIPTION
`lpass status` asks the agent to see if we are logged in or not. The
code for the logout bit checks the session and if a session has gone
stale it want to refresh it. Implement a similar logic as in
cmd-status.c where we ask the agent if we have a session, if we do,
proceed as always, else, wipe all the session data that we can find.
This removes the if-logic in session kill, to delete all config files
even if they for whatever reason do not exist. Since we want to kill it,
it seems logical to ignore these missing files.

Fixes: #477

Signed-off-by: Wesley Schwengle <wesley@schwengle.net>