### PR TITLE
Fix non-default PKG_CONFIG_PATH on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ if((APPLE) AND (NOT DEFINED OPENSSL_ROOT_DIR))
 endif()
 
 if((APPLE))
-  set(ENV{PKG_CONFIG_PATH} "/usr/local/opt/curl/lib/pkgconfig")
+  set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:/usr/local/opt/curl/lib/pkgconfig")
 endif()
 
 find_package(LibXml2 REQUIRED)


### PR DESCRIPTION
PKG_CONFIG_PATH shouldn't be reset, only appended to or prepended to, so that the user can still use non-default paths if they need to. Additionally, package managers other than Homebrew (such as Nix) still need to be able to provide their own versions of packages, and aren't going to use Homebrew's default path to do so.