### PR TITLE
Refactor agent.c for socket initialisation

### DIFF
--- a/agent.c
+++ b/agent.c
@@ -136,6 +136,13 @@ static int agent_socket_get_cred(int fd, struct ucred *cred)
 }
 #endif
 
+void _assert_socket_sun_path(struct sockaddr_un *sa, char *path)
+{
+	if (strlen(path) >= sizeof(sa->sun_path))
+		die("Path too large for agent control socket.");
+}
+
+
 static void agent_run(unsigned const char key[KDF_HASH_LEN])
 {
 	char *agent_timeout_str;
@@ -158,8 +165,7 @@ static void agent_run(unsigned const char key[KDF_HASH_LEN])
 		alarm(agent_timeout);
 
 	_cleanup_free_ char *path = agent_socket_path();
-	if (strlen(path) >= sizeof(sa.sun_path))
-		die("Path too large for agent control socket.");
+	_assert_socket_sun_path(&sa, path);
 
 	fd = socket(AF_UNIX, SOCK_STREAM, 0);
 
@@ -209,8 +215,7 @@ void agent_kill(void)
 	int fd;
 
 	_cleanup_free_ char *path = agent_socket_path();
-	if (strlen(path) >= sizeof(sa.sun_path))
-		die("Path too large for agent control socket.");
+	_assert_socket_sun_path(&sa, path);
 
 	fd = socket(AF_UNIX, SOCK_STREAM, 0);
 
@@ -243,8 +248,7 @@ bool agent_ask(unsigned char key[KDF_HASH_LEN])
 	bool ret = false;
 
 	_cleanup_free_ char *path = agent_socket_path();
-	if (strlen(path) >= sizeof(sa.sun_path))
-		die("Path too large for agent control socket.");
+	_assert_socket_sun_path(&sa, path);
 
 	fd = socket(AF_UNIX, SOCK_STREAM, 0);
 


### PR DESCRIPTION
I was debugging something and say that some code got duplicated. I made a small change to move the logic into one function so it can be re-used. The goal is to create a struct/class that deals with the agent socket logic so we don't need to have path, fd, etc in multiple functions. But I haven't had the time to implement that. But this is a first iteration of that rewrite. 