### PR TITLE
clipboard: add wl-copy support

### DIFF
--- a/clipboard.c
+++ b/clipboard.c
@@ -89,8 +89,9 @@ void clipboard_open(void)
 		char *clipboard_command = getenv("LPASS_CLIPBOARD_COMMAND");
 		if (clipboard_command) {
 			exec_command(clipboard_command);
-			die("Unable to copy contents to clipboard. Please make sure you have `xclip`, `xsel`, `pbcopy`, or `putclip` installed.");
+			die("Unable to copy contents to clipboard. Please make sure you have `wl-clip`, `xclip`, `xsel`, `pbcopy`, or `putclip` installed.");
 		} else {
+			execlp("wl-copy", "wl-copy", NULL);
 			execlp("xclip", "xclip", "-selection", "clipboard", "-in", NULL);
 			execlp("xsel", "xsel", "--clipboard", "--input", NULL);
 			execlp("pbcopy", "pbcopy", NULL);


### PR DESCRIPTION
wl-copy appears to have become the de-facto standard command line
program for copying to the clipboard on Wayland, with multiple
implementations of the same interface\[1]\[2].

I think it makes sense for wl-copy to be preferred over xclip if both
are installed, since Wayland should generally be preferred over X11.

\[1]: https://github.com/bugaevc/wl-clipboard
\[2]: https://github.com/YaLTeR/wl-clipboard-rs

Signed-off-by: Alyssa Ross <hi@alyssa.is>