### PR TITLE
Add MFA support for Microsoft Authenticator

### DIFF
--- a/endpoints-login.c
+++ b/endpoints-login.c
@@ -75,7 +75,13 @@ static struct multifactor_type multifactor_types[] = {
 		.error_str = "outofbandrequired",
 		.error_failure_str = "multifactorresponsefailed",
 		.post_var = "otp"
-	}
+	},
+    {
+        .name = "Microsoft Authenticator Code",
+        .error_str = "microsoftauthrequired",
+        .error_failure_str = "microsoftauthfailed",
+        .post_var = "otp"
+    }
 };
 
 static void filter_error_message(char *message)


### PR DESCRIPTION
MS Authenticator is currently incompatible with this tool (#442). I noticed that MFA errors are mapped in an array of `multifactor_type`, which I've updated with the appropriate error codes for MS Authenticator (tested running through a debugger).

Fixes #442

Signed-off-by: John Hammerlund johnhammerlund@gmail.com