### PR TITLE
Mark global variable as extern

### DIFF
--- a/globals.c
+++ b/globals.c
@@ -1,0 +1,40 @@
+/*
+ *
+ * Copyright (C) 2014-2018 LastPass.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * In addition, as a special exception, the copyright holders give
+ * permission to link the code of portions of this program with the
+ * OpenSSL library under certain conditions as described in each
+ * individual source file, and distribute linked combinations
+ * including the two.
+ *
+ * You must obey the GNU General Public License in all respects
+ * for all of the code used other than OpenSSL.  If you modify
+ * file(s) with this exception, you may extend this exception to your
+ * version of the file(s), but you are not obligated to do so.  If you
+ * do not wish to do so, delete this exception statement from your
+ * version.  If you delete this exception statement from all source
+ * files in the program, then also delete it here.
+ *
+ * See LICENSE.OpenSSL for more details regarding this exception.
+ */
+
+#include "process.h"
+
+/* Globals */
+int ARGC;
+char **ARGV;

--- a/process.h
+++ b/process.h
@@ -4,8 +4,8 @@
 #include <stdbool.h>
 #include <sys/types.h>
 
-int ARGC;
-char **ARGV;
+extern int ARGC;
+extern char **ARGV;
 
 void process_set_name(const char *name);
 void process_disable_ptrace(void);


### PR DESCRIPTION
GCC now defaults to -fno-common. As a result, global variable accesses
are more efficient on various targets. In C, global variables with
multiple tentative definitions now result in linker errors.

Fix #532

Signed-off-by: Robert-André Mauchin <zebob.m@gmail.com>