### PR TITLE
password.c: auto-disable pinentry when connected through SSH

### DIFF
--- a/lpass.1.txt
+++ b/lpass.1.txt
@@ -81,9 +81,10 @@ The *pinentry* program, part of *gpg2*(1), may be used for inputting
 passwords if it is installed. A custom path to the *pinentry* program can be
 provided by the 'LPASS_PINENTRY' environment variable.
 
-If *pinentry* program is unavailable, or if the 'LPASS_DISABLE_PINENTRY'
-environment variable is set to 1, passwords will be read from standard input and a
-prompt will be displayed on standard error.
+If *pinentry* program is unavailable, if the 'LPASS_DISABLE_PINENTRY'
+environment variable is set to 1, or if an SSH connection is detected,
+passwords will be read from standard input and a prompt will be displayed
+on standard error.
 
 The program used for inputting passwords may also be configured by setting the
 'LPASS_ASKPASS' environment variable. 'LPASS_ASKPASS' is expected to be a

--- a/password.c
+++ b/password.c
@@ -227,6 +227,7 @@ char *password_prompt(const char *prompt, const char *error, const char *descfmt
 	_cleanup_free_ char *prompt_colon = NULL;
 	_cleanup_free_ char *password = NULL;
 	char *password_fallback;
+	char *ssh_detected;
 	char *askpass;
 	char *pinentry_fallback = "pinentry";
 	char *pinentry;
@@ -243,7 +244,8 @@ char *password_prompt(const char *prompt, const char *error, const char *descfmt
 	}
 
 	password_fallback = getenv("LPASS_DISABLE_PINENTRY");
-	if (password_fallback && !strcmp(password_fallback, "1")) {
+	ssh_detected = getenv("SSH_CONNECTION");
+	if ((password_fallback && !strcmp(password_fallback, "1")) || ssh_detected) {
 		va_start(params, descfmt);
 		password_fallback = password_prompt_fallback(prompt, error, descfmt, params);
 		va_end(params);


### PR DESCRIPTION
Fixes https://github.com/lastpass/lastpass-cli/issues/568

The only thing not mentioned in the title is that detecting an SSH connection is done by checking whether the environment variable `SSH_CONNECTION` is present or not.

---

An alternative might be to not change the behaviour, but instead (when detecting an SSH connection) print a message telling the user that if they are unable to enter the password, they might need to set `LPASS_DISABLE_PINENTRY=1` and try again.