### PR TITLE
Made ARGC and ARGV extern

### DIFF
--- a/process.c
+++ b/process.c
@@ -75,6 +75,8 @@ static void ptrace(__attribute__((unused)) int x,
 		   __attribute__((unused)) int w) {}
 #endif
 
+int ARGC;
+char **ARGV;
 
 #if defined(__linux__) || defined(__CYGWIN__) || (defined(__NetBSD__) && !defined(KERN_PROC_PATHNAME))
 static int pid_to_cmd(pid_t pid, char *cmd, size_t cmd_size)

--- a/process.h
+++ b/process.h
@@ -4,8 +4,8 @@
 #include <stdbool.h>
 #include <sys/types.h>
 
-int ARGC;
-char **ARGV;
+extern int ARGC;
+extern char **ARGV;
 
 void process_set_name(const char *name);
 void process_disable_ptrace(void);


### PR DESCRIPTION
`ARGV` and `ARGC` where fully declared in `process.h`, so I moved them to `process.c` and made them `extern` in the header file