### PR TITLE
Password History

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ version.h
 
 # IDE
 /.idea
+/cmake-build-debug

--- a/cmd-history.c
+++ b/cmd-history.c
@@ -1,0 +1,174 @@
+/*
+ * command to show the password history of a vault entry
+ *
+ * Copyright (C) 2014-2018 LastPass.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * In addition, as a special exception, the copyright holders give
+ * permission to link the code of portions of this program with the
+ * OpenSSL library under certain conditions as described in each
+ * individual source file, and distribute linked combinations
+ * including the two.
+ *
+ * You must obey the GNU General Public License in all respects
+ * for all of the code used other than OpenSSL.  If you modify
+ * file(s) with this exception, you may extend this exception to your
+ * version of the file(s), but you are not obligated to do so.  If you
+ * do not wish to do so, delete this exception statement from your
+ * version.  If you delete this exception statement from all source
+ * files in the program, then also delete it here.
+ *
+ * See LICENSE.OpenSSL for more details regarding this exception.
+ */
+#include "cmd.h"
+#include "cipher.h"
+#include "util.h"
+#include "terminal.h"
+#include "kdf.h"
+#include "endpoints.h"
+#include "clipboard.h"
+#include "format.h"
+#include "tiny-json.h"
+#include <getopt.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdbool.h>
+
+#ifndef JSON_POOL_SIZE
+#define JSON_POOL_SIZE 1024
+#endif
+
+static void print_header(char *title_format, struct account *found) {
+    struct buffer buf;
+
+    buffer_init(&buf);
+    format_account(&buf, title_format, found);
+    terminal_printf("%s\n", buf.bytes);
+    free(buf.bytes);
+}
+
+static void print_field(char *field_format, struct account *account,
+                        char *name, char *value) {
+    struct buffer buf;
+
+    buffer_init(&buf);
+    format_field(&buf, field_format, account, name, value);
+    terminal_printf("%s\n", buf.bytes);
+    free(buf.bytes);
+}
+
+int cmd_history(int argc, char **argv) {
+    unsigned char key[KDF_HASH_LEN];
+    struct session *session = NULL;
+    struct blob *blob = NULL;
+    json_t pool[JSON_POOL_SIZE];
+    static struct option long_options[] = {
+            {"title-format", required_argument, NULL, 't'},
+            {"format",       required_argument, NULL, 'o'},
+            {"json",         no_argument,       NULL, 'j'},
+            {0, 0, 0,                                 0}
+    };
+
+    int option;
+    int option_index;
+    char *name;
+    enum blobsync sync = BLOB_SYNC_AUTO;
+    bool clip = false;
+    bool json = false;
+
+    _cleanup_free_ char *title_format = NULL;
+    _cleanup_free_ char *field_format = NULL;
+
+    while ((option = getopt_long(argc, argv, "toj", long_options, &option_index)) != -1) {
+        switch (option) {
+            case 'j':
+                json = true;
+                break;
+            case 'o':
+                field_format = xstrdup(optarg);
+                break;
+            case 't':
+                title_format = xstrdup(optarg);
+                break;
+            case '?':
+            default:
+                die_usage(cmd_history_usage);
+        }
+    }
+
+    if (argc - optind < 1)
+        die_usage(cmd_history_usage);
+
+    name = argv[optind];
+
+    if (!title_format) {
+        title_format = xstrdup(
+                TERMINAL_FG_CYAN "%/as" TERMINAL_RESET
+                TERMINAL_FG_BLUE "%/ag"
+                TERMINAL_BOLD "%an" TERMINAL_RESET
+                TERMINAL_FG_GREEN " [id: %ai]" TERMINAL_RESET);
+    }
+    if (!field_format) {
+        field_format = xstrdup(
+                TERMINAL_FG_YELLOW "%fn" TERMINAL_RESET ": %fv");
+    }
+
+    init_all(sync, key, &session, &blob);
+
+    struct account *found_account = find_unique_account(blob, name);
+
+    char *result = lastpass_get_password_history_json(session, found_account, key);
+
+    print_header(title_format, found_account);
+
+    if (clip)
+        clipboard_open();
+
+    if (json) {
+        puts(result);
+        goto done;
+    }
+
+    json_t const *parent = json_create(result, pool, JSON_POOL_SIZE);
+    if (parent == NULL) die("Malformed JSON");
+
+    json_t const *history_field = json_getProperty(parent, "history");
+    if (history_field == NULL || TINY_JSON_ARRAY != json_getType(history_field)) die("No history present");
+
+    json_t const *entry;
+    for (entry = json_getChild(history_field); entry != 0; entry = json_getSibling(entry)) {
+        if (JSON_OBJ == json_getType(entry)) {
+            char const *date = json_getPropertyValue(entry, "date");
+            char const *password = json_getPropertyValue(entry, "value");
+            char const *whom = json_getPropertyValue(entry, "value");
+            char *decyphered = cipher_aes_decrypt_base64(password, key);
+
+            char *date_copy = calloc(strlen(date) + 1, 1);
+            strcpy(date_copy, date);
+
+            char *whom_copy = calloc(strlen(whom) + 1, 1);
+            strcpy(whom_copy, whom);
+
+            print_field(field_format, found_account, date_copy, decyphered);
+        }
+    }
+
+    done:
+    session_free(session);
+    blob_free(blob);
+    free(result);
+    return 0;
+}

--- a/cmd.c
+++ b/cmd.c
@@ -194,7 +194,7 @@ void find_matching_accounts(struct list_head *accounts, const char *name,
 	/* look for exact id match */
 	struct account *account;
 	list_for_each_entry(account, accounts, match_list) {
-		if (strcmp(name, "0") && !strcasecmp(account->id, name)) {
+		if (strcmp(name, "0") != 0 && !strcasecmp(account->id, name)) {
 			list_del(&account->match_list);
 			list_add_tail(&account->match_list, ret_list);
 			/* if id match, stop processing */

--- a/cmd.h
+++ b/cmd.h
@@ -83,6 +83,9 @@ int cmd_passwd(int argc, char **argv);
 int cmd_show(int argc, char **argv);
 #define cmd_show_usage "show [--sync=auto|now|no] [--clip, -c] [--quiet, -q] [--expand-multi, -x] [--json, -j] [--all|--username|--password|--url|--notes|--field=FIELD|--id|--name|--attach=ATTACHID] [--basic-regexp, -G|--fixed-strings, -F] " color_usage " {UNIQUENAME|UNIQUEID}"
 
+int cmd_history(int argc, char **argv);
+#define cmd_history_usage "history [--clip, -c] [--json, -j] " color_usage " {UNIQUENAME|UNIQUEID}"
+
 int cmd_ls(int argc, char **argv);
 #define cmd_ls_usage "ls [--sync=auto|now|no] [--long, -l] [-m] [-u] " color_usage " [GROUP]"
 

--- a/contrib/completions-lpass.fish
+++ b/contrib/completions-lpass.fish
@@ -53,6 +53,8 @@ complete -f -c lpass -n '__lpass_needs_command' -a share \
     -d 'Perform operations on a share'
 complete -f -c lpass -n '__lpass_needs_command' -a show \
     -d 'Show entry details'
+complete -f -c lpass -n '__lpass_needs_command' -a history \
+    -d 'Show password history of entry'
 complete -f -c lpass -n '__lpass_needs_command' -a status \
     -d 'Show status'
 complete -f -c lpass -n '__lpass_needs_command' -a sync \
@@ -60,7 +62,7 @@ complete -f -c lpass -n '__lpass_needs_command' -a sync \
 
 # {UNIQUENAME|UNIQUEID}
 complete -f -c lpass \
-    -n '__lpass_using_command show mv edit generate duplicate rm' \
+    -n '__lpass_using_command show history mv edit generate duplicate rm' \
     -a '(__lpass_entries)'
 
 # --all
@@ -84,13 +86,13 @@ complete -f -c lpass -n '__lpass_using_command show' \
     -d 'Search with regular expression'
 
 # --clip -c
-complete -f -c lpass -n '__lpass_using_command show generate' \
+complete -f -c lpass -n '__lpass_using_command show history generate' \
     -s c -l clip \
     -d 'Copy output to clipboard'
 
 # --color=COLOR
 complete -f -c lpass \
-    -n '__lpass_using_command login logout show ls mv add edit duplicate rm sync export status' \
+    -n '__lpass_using_command login logout show history ls mv add edit duplicate rm sync export status' \
     -r -l color \
     -a 'auto never always' \
     -d 'When to use colors'
@@ -121,7 +123,7 @@ complete -f -c lpass -n '__lpass_using_command login logout' \
     -d 'Do not ask for confirmation'
 
 # --format=FMTSTR
-complete -f -c lpass -n '__lpass_using_command show ls' \
+complete -f -c lpass -n '__lpass_using_command show history ls' \
     -l format \
     -d 'Format string'
 

--- a/contrib/lpass_bash_completion
+++ b/contrib/lpass_bash_completion
@@ -62,6 +62,9 @@ __lpass_complete_opt()
         show)
             opts="--sync --clip --expand-multi --all --username --password --url --notes --field --id --name --basic-regexp --fixed-strings --color"
             ;;
+        history)
+			opts="--clip --color"
+			;;
         ls)
             opts="--sync --long --color"
             ;;
@@ -99,8 +102,8 @@ _lpass()
     local name="${COMP_WORDS[$optind]}"
 
     local all_cmds="
-        login logout passwd show ls mv add edit generate
-        duplicate rm sync export import share
+        login logout passwd show history ls mv add edit
+        generate duplicate rm sync export import share
     "
     local share_cmds="
         userls useradd usermod userdel create rm
@@ -138,7 +141,7 @@ _lpass()
     esac
 
     case "$cmd" in
-        show|rm|edit|duplicate|generate)
+        show|history|rm|edit|duplicate|generate)
             __lpass_complete_name $cur
             ;;
         mv)

--- a/contrib/lpass_zsh_completion
+++ b/contrib/lpass_zsh_completion
@@ -35,6 +35,16 @@ _lpass() {
                 has_sync=1
             ;;
 
+            history)
+				_arguments : \
+				  '(-c --clip)'{-c,--clip}'[Copy output to clipboard]' \
+				  '(-o --format)'{-o,--format}'[Format output with printf-style placeholders]'
+				  '(-t --title-format)'{-t,--title-format}'[Format title with printf-style placeholders]'
+				_lpass_complete_uniqenames
+				has_color=1
+				has_sync=1
+			;;
+
             ls)
                 _arguments : \
                   '(-l --long)'{-l,--long}'[Also list the last modification time and username]' \

--- a/endpoints.c
+++ b/endpoints.c
@@ -74,6 +74,20 @@ struct blob *lastpass_get_blob(const struct session *session, const unsigned cha
 	return blob_parse((unsigned char *) blob, len, key, &session->private_key);
 }
 
+char *lastpass_get_password_history_json(const struct session *session, struct account *account, const unsigned char key[KDF_HASH_LEN])
+{
+    size_t len = 33 + strlen(account->id);
+    _cleanup_free_ char *page = calloc(len, 1);
+    sprintf(page, "lmiapi/accounts/%s/history/password", account->id);
+
+    char *json = http_get_lastpass(page, session, &len);
+
+    if (!json || !len)
+        return NULL;
+
+    return json;
+}
+
 void lastpass_remove_account(enum blobsync sync, unsigned const char key[KDF_HASH_LEN], const struct session *session, const struct account *account, struct blob *blob)
 {
 	struct http_param_set params = {

--- a/endpoints.h
+++ b/endpoints.h
@@ -10,6 +10,7 @@ unsigned int lastpass_iterations(const char *username);
 struct session *lastpass_login(const char *username, const char hash[KDF_HEX_LEN], const unsigned char key[KDF_HASH_LEN], int iterations, char **error_message, bool trust);
 void lastpass_logout(const struct session *session);
 struct blob *lastpass_get_blob(const struct session *session, const unsigned char key[KDF_HASH_LEN]);
+char *lastpass_get_password_history_json(const struct session *session, struct account *account, const unsigned char key[KDF_HASH_LEN]);
 unsigned long long lastpass_get_blob_version(struct session *session, unsigned const char key[KDF_HASH_LEN]);
 void lastpass_remove_account(enum blobsync sync, unsigned const char key[KDF_HASH_LEN], const struct session *session, const struct account *account, struct blob *blob);
 void lastpass_update_account(enum blobsync sync, unsigned const char key[KDF_HASH_LEN], const struct session *session, const struct account *account, struct blob *blob);

--- a/http.c
+++ b/http.c
@@ -213,6 +213,18 @@ void http_post_add_params(struct http_param_set *param_set, ...)
 	va_end(args);
 }
 
+char *http_get_lastpass(const char *page, const struct session *session, size_t *final_len)
+{
+    char* argv_ref = {0};
+    struct http_param_set params = {
+            .argv = &argv_ref,
+            .n_alloced = 0
+    };
+
+    char *result = http_post_lastpass_param_set(page, session, final_len, &params);
+    return result;
+}
+
 char *http_post_lastpass(const char *page, const struct session *session, size_t *final_len, ...)
 {
 	va_list args;

--- a/http.h
+++ b/http.h
@@ -19,6 +19,7 @@ struct http_param_set
 
 int http_init();
 void http_post_add_params(struct http_param_set *params, ...);
+char *http_get_lastpass(const char *page, const struct session *session, size_t *len);
 char *http_post_lastpass(const char *page, const struct session *session, size_t *len, ...);
 char *http_post_lastpass_v(const char *server, const char *page, const struct session *session, size_t *len, char **argv);
 char *http_post_lastpass_param_set(const char *page, const struct session *session, size_t *len,

--- a/lpass.1.txt
+++ b/lpass.1.txt
@@ -25,6 +25,7 @@ several subcommands:
  lpass *logout* [--force, -f] [--color=auto|never|always]
  lpass *passwd*
  lpass *show* [--sync=auto|now|no] [--clip, -c] [--quiet, -q] [--expand-multi, -x] [--json, -j] [--all|--username|--password|--url|--notes|--field=FIELD|--id|--name|--attach=ATTACHID] [--basic-regexp, -G|--fixed-strings, -F] [--color=auto|never|always] {NAME|UNIQUEID}*
+ lpass *history* [--clip, -c] [--json, -j] [--color=auto|never|always] {NAME|UNIQUEID}
  lpass *ls* [--sync=auto|now|no] [--long, -l] [-m] [-u] [--color=auto|never|always] [GROUP]
  lpass *mv* [--sync=auto|now|no] [--color=auto|never|always] {UNIQUENAME|UNIQUEID} GROUP
  lpass *add* [--sync=auto|now|no] [--non-interactive] {--name|--username, -u|--password, -p|--url|--notes|--field=FIELD|--note-type=NOTETYPE} [--color=auto|never|always] {NAME|UNIQUEID}
@@ -143,6 +144,9 @@ matching sites but no other information.  The '--expand-multi' or '-x'
 option will instead show the requested information from all of the
 matching sites.
 
+The 'history' subcommand shows the history of passwords for a given entry.
+Like the 'show' subcommand, the name of the site must match *exactly*.
+
 The 'ls' subcommand will list names in groups in a tree structure. If
 the '--long' or '-l' option is set, then also list the last modification
 time.  The '-u' option may be passed to show the last use (last touch) time
@@ -151,9 +155,9 @@ instead, if available. Both times are in GMT.
 Passing '--json' to 'show' will generate json output instead of
 human-readable text.
 
-In addition to using the built-in formats, both 'show' and 'ls' subcommands
-support printf-style format strings by using the '--format' option with
-the following placeholders:
+In addition to using the built-in formats, both 'show', 'history', and 'ls'
+subcommands support printf-style format strings by using the '--format'
+option with the following placeholders:
 
 * %ai: account id
 * %an: account name

--- a/lpass.c
+++ b/lpass.c
@@ -60,6 +60,7 @@ static struct {
 	CMD(logout),
 	CMD(passwd),
 	CMD(show),
+    CMD(history),
 	CMD(ls),
 	CMD(mv),
 	CMD(add),

--- a/process.c
+++ b/process.c
@@ -127,6 +127,9 @@ out:
 #error "Please provide a pid_to_cmd for your platform"
 #endif
 
+int ARGC;
+char **ARGV;
+
 void process_set_name(const char *name)
 {
 	size_t argslen = 0;

--- a/process.h
+++ b/process.h
@@ -4,8 +4,8 @@
 #include <stdbool.h>
 #include <sys/types.h>
 
-int ARGC;
-char **ARGV;
+extern int ARGC;
+extern char **ARGV;
 
 void process_set_name(const char *name);
 void process_disable_ptrace(void);

--- a/tiny-json.c
+++ b/tiny-json.c
@@ -1,0 +1,460 @@
+/*
+
+<https://github.com/rafagafe/tiny-json>
+
+  Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+  SPDX-License-Identifier: MIT
+  Copyright (c) 2016-2018 Rafa Garcia <rafagarcia77@gmail.com>.
+
+  Permission is hereby  granted, free of charge, to any  person obtaining a copy
+  of this software and associated  documentation files (the "Software"), to deal
+  in the Software  without restriction, including without  limitation the rights
+  to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+  copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+  IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+  FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+  AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+  LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+
+*/
+
+#include <string.h>
+#include <ctype.h>
+#include "tiny-json.h"
+
+/** Structure to handle a heap of JSON properties. */
+typedef struct jsonStaticPool_s {
+    json_t* mem;      /**< Pointer to array of json properties.      */
+    unsigned int qty; /**< Length of the array of json properties.   */
+    unsigned int nextFree;  /**< The index of the next free json property. */
+    jsonPool_t pool;
+} jsonStaticPool_t;
+
+/* Search a property by its name in a JSON object. */
+json_t const* json_getProperty( json_t const* obj, char const* property ) {
+    json_t const* sibling;
+    for( sibling = obj->u.c.child; sibling; sibling = sibling->sibling )
+        if ( sibling->name && !strcmp( sibling->name, property ) )
+            return sibling;
+    return 0;
+}
+
+/* Search a property by its name in a JSON object and return its value. */
+char const* json_getPropertyValue( json_t const* obj, char const* property ) {
+    json_t const* field = json_getProperty( obj, property );
+    if ( !field ) return 0;
+    jsonType_t type = json_getType( field );
+    if ( TINY_JSON_ARRAY >= type ) return 0;
+    return json_getValue( field );
+}
+
+/* Internal prototypes: */
+static char* goBlank( char* str );
+static char* goNum( char* str );
+static json_t* poolInit( jsonPool_t* pool );
+static json_t* poolAlloc( jsonPool_t* pool );
+static char* objValue( char* ptr, json_t* obj, jsonPool_t* pool );
+static char* setToNull( char* ch );
+static bool isEndOfPrimitive( char ch );
+
+/* Parse a string to get a json. */
+json_t const* json_createWithPool( char *str, jsonPool_t *pool ) {
+    char* ptr = goBlank( str );
+    if ( !ptr || (*ptr != '{' && *ptr != '[') ) return 0;
+    json_t* obj = pool->init( pool );
+    obj->name    = 0;
+    obj->sibling = 0;
+    obj->u.c.child = 0;
+    ptr = objValue( ptr, obj, pool );
+    if ( !ptr ) return 0;
+    return obj;
+}
+
+/* Parse a string to get a json. */
+json_t const* json_create( char* str, json_t mem[], unsigned int qty ) {
+    jsonStaticPool_t spool;
+    spool.mem = mem;
+    spool.qty = qty;
+    spool.pool.init = poolInit;
+    spool.pool.alloc = poolAlloc;
+    return json_createWithPool( str, &spool.pool );
+}
+
+/** Get a special character with its escape character. Examples:
+  * 'b' -> '\\b', 'n' -> '\\n', 't' -> '\\t'
+  * @param ch The escape character.
+  * @retval  The character code. */
+static char getEscape( char ch ) {
+    static struct { char ch; char code; } const pair[] = {
+            { '\"', '\"' }, { '\\', '\\' },
+            { '/',  '/'  }, { 'b',  '\b' },
+            { 'f',  '\f' }, { 'n',  '\n' },
+            { 'r',  '\r' }, { 't',  '\t' },
+    };
+    unsigned int i;
+    for( i = 0; i < sizeof pair / sizeof *pair; ++i )
+        if ( pair[i].ch == ch )
+            return pair[i].code;
+    return '\0';
+}
+
+/** Parse 4 characters.
+  * @param str Pointer to  first digit.
+  * @retval '?' If the four characters are hexadecimal digits.
+  * @retval '\0' In other cases. */
+static unsigned char getCharFromUnicode( unsigned char const* str ) {
+    unsigned int i;
+    for( i = 0; i < 4; ++i )
+        if ( !isxdigit( str[i] ) )
+            return '\0';
+    return '?';
+}
+
+/** Parse a string and replace the scape characters by their meaning characters.
+  * This parser stops when finds the character '\"'. Then replaces '\"' by '\0'.
+  * @param str Pointer to first character.
+  * @retval Pointer to first non white space after the string. If success.
+  * @retval Null pointer if any error occur. */
+static char* parseString( char* str ) {
+    unsigned char* head = (unsigned char*)str;
+    unsigned char* tail = (unsigned char*)str;
+    for( ; *head; ++head, ++tail ) {
+        if ( *head == '\"' ) {
+            *tail = '\0';
+            return (char*)++head;
+        }
+        if ( *head == '\\' ) {
+            if ( *++head == 'u' ) {
+                char const ch = getCharFromUnicode( ++head );
+                if ( ch == '\0' ) return 0;
+                *tail = ch;
+                head += 3;
+            }
+            else {
+                char const esc = getEscape( *head );
+                if ( esc == '\0' ) return 0;
+                *tail = esc;
+            }
+        }
+        else *tail = *head;
+    }
+    return 0;
+}
+
+/** Parse a string to get the name of a property.
+  * @param ptr Pointer to first character.
+  * @param property The property to assign the name.
+  * @retval Pointer to first of property value. If success.
+  * @retval Null pointer if any error occur. */
+static char* propertyName( char* ptr, json_t* property ) {
+    property->name = ++ptr;
+    ptr = parseString( ptr );
+    if ( !ptr ) return 0;
+    ptr = goBlank( ptr );
+    if ( !ptr ) return 0;
+    if ( *ptr++ != ':' ) return 0;
+    return goBlank( ptr );
+}
+
+/** Parse a string to get the value of a property when its type is JSON_TEXT.
+  * @param ptr Pointer to first character ('\"').
+  * @param property The property to assign the name.
+  * @retval Pointer to first non white space after the string. If success.
+  * @retval Null pointer if any error occur. */
+static char* textValue( char* ptr, json_t* property ) {
+    ++property->u.value;
+    ptr = parseString( ++ptr );
+    if ( !ptr ) return 0;
+    property->type = JSON_TEXT;
+    return ptr;
+}
+
+/** Compare two strings until get the null character in the second one.
+  * @param ptr sub string
+  * @param str main string
+  * @retval Pointer to next character.
+  * @retval Null pointer if any error occur. */
+static char* checkStr( char* ptr, char const* str ) {
+    while( *str )
+        if ( *ptr++ != *str++ )
+            return 0;
+    return ptr;
+}
+
+/** Parser a string to get a primitive value.
+  * If the first character after the value is different of '}' or ']' is set to '\0'.
+  * @param ptr Pointer to first character.
+  * @param property Property handler to set the value and the type, (true, false or null).
+  * @param value String with the primitive literal.
+  * @param type The code of the type. ( JSON_BOOLEAN or JSON_NULL )
+  * @retval Pointer to first non white space after the string. If success.
+  * @retval Null pointer if any error occur. */
+static char* primitiveValue( char* ptr, json_t* property, char const* value, jsonType_t type ) {
+    ptr = checkStr( ptr, value );
+    if ( !ptr || !isEndOfPrimitive( *ptr ) ) return 0;
+    ptr = setToNull( ptr );
+    property->type = type;
+    return ptr;
+}
+
+/** Parser a string to get a true value.
+  * If the first character after the value is different of '}' or ']' is set to '\0'.
+  * @param ptr Pointer to first character.
+  * @param property Property handler to set the value and the type, (true, false or null).
+  * @retval Pointer to first non white space after the string. If success.
+  * @retval Null pointer if any error occur. */
+static char* trueValue( char* ptr, json_t* property ) {
+    return primitiveValue( ptr, property, "true", JSON_BOOLEAN );
+}
+
+/** Parser a string to get a false value.
+  * If the first character after the value is different of '}' or ']' is set to '\0'.
+  * @param ptr Pointer to first character.
+  * @param property Property handler to set the value and the type, (true, false or null).
+  * @retval Pointer to first non white space after the string. If success.
+  * @retval Null pointer if any error occur. */
+static char* falseValue( char* ptr, json_t* property ) {
+    return primitiveValue( ptr, property, "false", JSON_BOOLEAN );
+}
+
+/** Parser a string to get a null value.
+  * If the first character after the value is different of '}' or ']' is set to '\0'.
+  * @param ptr Pointer to first character.
+  * @param property Property handler to set the value and the type, (true, false or null).
+  * @retval Pointer to first non white space after the string. If success.
+  * @retval Null pointer if any error occur. */
+static char* nullValue( char* ptr, json_t* property ) {
+    return primitiveValue( ptr, property, "null", JSON_NULL );
+}
+
+/** Analyze the exponential part of a real number.
+  * @param ptr Pointer to first character.
+  * @retval Pointer to first non numerical after the string. If success.
+  * @retval Null pointer if any error occur. */
+static char* expValue( char* ptr ) {
+    if ( *ptr == '-' || *ptr == '+' ) ++ptr;
+    if ( !isdigit( (int)(*ptr) ) ) return 0;
+    ptr = goNum( ++ptr );
+    return ptr;
+}
+
+/** Analyze the decimal part of a real number.
+  * @param ptr Pointer to first character.
+  * @retval Pointer to first non numerical after the string. If success.
+  * @retval Null pointer if any error occur. */
+static char* fraqValue( char* ptr ) {
+    if ( !isdigit( (int)(*ptr) ) ) return 0;
+    ptr = goNum( ++ptr );
+    if ( !ptr ) return 0;
+    return ptr;
+}
+
+/** Parser a string to get a numerical value.
+  * If the first character after the value is different of '}' or ']' is set to '\0'.
+  * @param ptr Pointer to first character.
+  * @param property Property handler to set the value and the type: JSON_REAL or JSON_INTEGER.
+  * @retval Pointer to first non white space after the string. If success.
+  * @retval Null pointer if any error occur. */
+static char* numValue( char* ptr, json_t* property ) {
+    if ( *ptr == '-' ) ++ptr;
+    if ( !isdigit( (int)(*ptr) ) ) return 0;
+    if ( *ptr != '0' ) {
+        ptr = goNum( ptr );
+        if ( !ptr ) return 0;
+    }
+    else if ( isdigit( (int)(*++ptr) ) ) return 0;
+    property->type = JSON_INTEGER;
+    if ( *ptr == '.' ) {
+        ptr = fraqValue( ++ptr );
+        if ( !ptr ) return 0;
+        property->type = JSON_REAL;
+    }
+    if ( *ptr == 'e' || *ptr == 'E' ) {
+        ptr = expValue( ++ptr );
+        if ( !ptr ) return 0;
+        property->type = JSON_REAL;
+    }
+    if ( !isEndOfPrimitive( *ptr ) ) return 0;
+    if ( JSON_INTEGER == property->type ) {
+        char const* value = property->u.value;
+        bool const negative = *value == '-';
+        static char const min[] = "-9223372036854775808";
+        static char const max[] = "9223372036854775807";
+        unsigned int const maxdigits = ( negative? sizeof min: sizeof max ) - 1;
+        unsigned int const len = ( unsigned int const ) ( ptr - value );
+        if ( len > maxdigits ) return 0;
+        if ( len == maxdigits ) {
+            char const tmp = *ptr;
+            *ptr = '\0';
+            char const* const threshold = negative ? min: max;
+            if ( 0 > strcmp( threshold, value ) ) return 0;
+            *ptr = tmp;
+        }
+    }
+    ptr = setToNull( ptr );
+    return ptr;
+}
+
+/** Add a property to a JSON object or array.
+  * @param obj The handler of the JSON object or array.
+  * @param property The handler of the property to be added. */
+static void add( json_t* obj, json_t* property ) {
+    property->sibling = 0;
+    if ( !obj->u.c.child ){
+        obj->u.c.child = property;
+        obj->u.c.last_child = property;
+    } else {
+        obj->u.c.last_child->sibling = property;
+        obj->u.c.last_child = property;
+    }
+}
+
+/** Parser a string to get a json object value.
+  * @param ptr Pointer to first character.
+  * @param obj The handler of the JSON root object or array.
+  * @param pool The handler of a json pool for creating json instances.
+  * @retval Pointer to first character after the value. If success.
+  * @retval Null pointer if any error occur. */
+static char* objValue( char* ptr, json_t* obj, jsonPool_t* pool ) {
+    obj->type    = *ptr == '{' ? JSON_OBJ : TINY_JSON_ARRAY;
+    obj->u.c.child = 0;
+    obj->sibling = 0;
+    ptr++;
+    for(;;) {
+        ptr = goBlank( ptr );
+        if ( !ptr ) return 0;
+        if ( *ptr == ',' ) {
+            ++ptr;
+            continue;
+        }
+        char const endchar = ( obj->type == JSON_OBJ )? '}': ']';
+        if ( *ptr == endchar ) {
+            *ptr = '\0';
+            json_t* parentObj = obj->sibling;
+            if ( !parentObj ) return ++ptr;
+            obj->sibling = 0;
+            obj = parentObj;
+            ++ptr;
+            continue;
+        }
+        json_t* property = pool->alloc( pool );
+        if ( !property ) return 0;
+        if( obj->type != TINY_JSON_ARRAY ) {
+            if ( *ptr != '\"' ) return 0;
+            ptr = propertyName( ptr, property );
+            if ( !ptr ) return 0;
+        }
+        else property->name = 0;
+        add( obj, property );
+        property->u.value = ptr;
+        switch( *ptr ) {
+            case '{':
+                property->type    = JSON_OBJ;
+                property->u.c.child = 0;
+                property->sibling = obj;
+                obj = property;
+                ++ptr;
+                break;
+            case '[':
+                property->type    = TINY_JSON_ARRAY;
+                property->u.c.child = 0;
+                property->sibling = obj;
+                obj = property;
+                ++ptr;
+                break;
+            case '\"': ptr = textValue( ptr, property );  break;
+            case 't':  ptr = trueValue( ptr, property );  break;
+            case 'f':  ptr = falseValue( ptr, property ); break;
+            case 'n':  ptr = nullValue( ptr, property );  break;
+            default:   ptr = numValue( ptr, property );   break;
+        }
+        if ( !ptr ) return 0;
+    }
+}
+
+/** Initialize a json pool.
+  * @param pool The handler of the pool.
+  * @return a instance of a json. */
+static json_t* poolInit( jsonPool_t* pool ) {
+    jsonStaticPool_t *spool = json_containerOf( pool, jsonStaticPool_t, pool );
+    spool->nextFree = 1;
+    return spool->mem;
+}
+
+/** Create an instance of a json from a pool.
+  * @param pool The handler of the pool.
+  * @retval The handler of the new instance if success.
+  * @retval Null pointer if the pool was empty. */
+static json_t* poolAlloc( jsonPool_t* pool ) {
+    jsonStaticPool_t *spool = json_containerOf( pool, jsonStaticPool_t, pool );
+    if ( spool->nextFree >= spool->qty ) return 0;
+    return spool->mem + spool->nextFree++;
+}
+
+/** Checks whether an character belongs to set.
+  * @param ch Character value to be checked.
+  * @param set Set of characters. It is just a null-terminated string.
+  * @return true or false there is membership or not. */
+static bool isOneOfThem( char ch, char const* set ) {
+    while( *set != '\0' )
+        if ( ch == *set++ )
+            return true;
+    return false;
+}
+
+/** Increases a pointer while it points to a character that belongs to a set.
+  * @param str The initial pointer value.
+  * @param set Set of characters. It is just a null-terminated string.
+  * @return The final pointer value or null pointer if the null character was found. */
+static char* goWhile( char* str, char const* set ) {
+    for(; *str != '\0'; ++str ) {
+        if ( !isOneOfThem( *str, set ) )
+            return str;
+    }
+    return 0;
+}
+
+/** Set of characters that defines a blank. */
+static char const* const blank = " \n\r\t\f";
+
+/** Increases a pointer while it points to a white space character.
+  * @param str The initial pointer value.
+  * @return The final pointer value or null pointer if the null character was found. */
+static char* goBlank( char* str ) {
+    return goWhile( str, blank );
+}
+
+/** Increases a pointer while it points to a decimal digit character.
+  * @param str The initial pointer value.
+  * @return The final pointer value or null pointer if the null character was found. */
+static char* goNum( char* str ) {
+    for( ; *str != '\0'; ++str ) {
+        if ( !isdigit( (int)(*str) ) )
+            return str;
+    }
+    return 0;
+}
+
+/** Set of characters that defines the end of an array or a JSON object. */
+static char const* const endofblock = "}]";
+
+/** Set a char to '\0' and increase its pointer if the char is different to '}' or ']'.
+  * @param ch Pointer to character.
+  * @return  Final value pointer. */
+static char* setToNull( char* ch ) {
+    if ( !isOneOfThem( *ch, endofblock ) ) *ch++ = '\0';
+    return ch;
+}
+
+/** Indicate if a character is the end of a primitive value. */
+static bool isEndOfPrimitive( char ch ) {
+    return ch == ',' || isOneOfThem( ch, blank ) || isOneOfThem( ch, endofblock );
+}

--- a/tiny-json.h
+++ b/tiny-json.h
@@ -1,0 +1,175 @@
+/*
+
+<https://github.com/rafagafe/tiny-json>
+
+  Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+  SPDX-License-Identifier: MIT
+  Copyright (c) 2016-2018 Rafa Garcia <rafagarcia77@gmail.com>.
+
+  Permission is hereby  granted, free of charge, to any  person obtaining a copy
+  of this software and associated  documentation files (the "Software"), to deal
+  in the Software  without restriction, including without  limitation the rights
+  to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+  copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+  IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+  FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+  AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+  LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+
+*/
+
+#ifndef _TINY_JSON_H_
+#define	_TINY_JSON_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#define json_containerOf( ptr, type, member ) \
+    ((type*)( (char*)ptr - offsetof( type, member ) ))
+
+/** @defgroup tinyJson Tiny JSON parser.
+  * @{ */
+
+/** Enumeration of codes of supported JSON properties types. */
+typedef enum {
+    JSON_OBJ, TINY_JSON_ARRAY, JSON_TEXT, JSON_BOOLEAN,
+    JSON_INTEGER, JSON_REAL, JSON_NULL
+} jsonType_t;
+
+/** Structure to handle JSON properties. */
+typedef struct json_s {
+    struct json_s* sibling;
+    char const* name;
+    union {
+        char const* value;
+        struct {
+            struct json_s* child;
+            struct json_s* last_child;
+        } c;
+    } u;
+    jsonType_t type;
+} json_t;
+
+/** Parse a string to get a json.
+  * @param str String pointer with a JSON object. It will be modified.
+  * @param mem Array of json properties to allocate.
+  * @param qty Number of elements of mem.
+  * @retval Null pointer if any was wrong in the parse process.
+  * @retval If the parser process was successfully a valid handler of a json.
+  *         This property is always unnamed and its type is JSON_OBJ. */
+json_t const* json_create( char* str, json_t mem[], unsigned int qty );
+
+/** Get the name of a json property.
+  * @param json A valid handler of a json property.
+  * @retval Pointer to null-terminated if property has name.
+  * @retval Null pointer if the property is unnamed. */
+static inline char const* json_getName( json_t const* json ) {
+    return json->name;
+}
+
+/** Get the value of a json property.
+  * The type of property cannot be JSON_OBJ or TINY_JSON_ARRAY.
+  * @param property A valid handler of a json property.
+  * @return Pointer to null-terminated string with the value. */
+static inline char const* json_getValue( json_t const* property ) {
+    return property->u.value;
+}
+
+/** Get the type of a json property.
+  * @param json A valid handler of a json property.
+  * @return The code of type.*/
+static inline jsonType_t json_getType( json_t const* json ) {
+    return json->type;
+}
+
+/** Get the next sibling of a JSON property that is within a JSON object or array.
+  * @param json A valid handler of a json property.
+  * @retval The handler of the next sibling if found.
+  * @retval Null pointer if the json property is the last one. */
+static inline json_t const* json_getSibling( json_t const* json ) {
+    return json->sibling;
+}
+
+/** Search a property by its name in a JSON object.
+  * @param obj A valid handler of a json object. Its type must be JSON_OBJ.
+  * @param property The name of property to get.
+  * @retval The handler of the json property if found.
+  * @retval Null pointer if not found. */
+json_t const* json_getProperty( json_t const* obj, char const* property );
+
+
+/** Search a property by its name in a JSON object and return its value.
+  * @param obj A valid handler of a json object. Its type must be JSON_OBJ.
+  * @param property The name of property to get.
+  * @retval If found a pointer to null-terminated string with the value.
+  * @retval Null pointer if not found or it is an array or an object. */
+char const* json_getPropertyValue( json_t const* obj, char const* property );
+
+/** Get the first property of a JSON object or array.
+  * @param json A valid handler of a json property.
+  *             Its type must be JSON_OBJ or TINY_JSON_ARRAY.
+  * @retval The handler of the first property if there is.
+  * @retval Null pointer if the json object has not properties. */
+static inline json_t const* json_getChild( json_t const* json ) {
+    return json->u.c.child;
+}
+
+/** Get the value of a json boolean property.
+  * @param property A valid handler of a json object. Its type must be JSON_BOOLEAN.
+  * @return The value stdbool. */
+static inline bool json_getBoolean( json_t const* property ) {
+    return *property->u.value == 't';
+}
+
+/** Get the value of a json integer property.
+  * @param property A valid handler of a json object. Its type must be JSON_INTEGER.
+  * @return The value stdint. */
+static inline int64_t json_getInteger( json_t const* property ) {
+    return strtoll( property->u.value,(char**)NULL, 10);
+}
+
+/** Get the value of a json real property.
+  * @param property A valid handler of a json object. Its type must be JSON_REAL.
+  * @return The value. */
+static inline double json_getReal( json_t const* property ) {
+    return strtod( property->u.value,(char**)NULL );
+}
+
+
+
+/** Structure to handle a heap of JSON properties. */
+typedef struct jsonPool_s jsonPool_t;
+struct jsonPool_s {
+    json_t* (*init)( jsonPool_t* pool );
+    json_t* (*alloc)( jsonPool_t* pool );
+};
+
+/** Parse a string to get a json.
+  * @param str String pointer with a JSON object. It will be modified.
+  * @param pool Custom json pool pointer.
+  * @retval Null pointer if any was wrong in the parse process.
+  * @retval If the parser process was successfully a valid handler of a json.
+  *         This property is always unnamed and its type is JSON_OBJ. */
+json_t const* json_createWithPool( char* str, jsonPool_t* pool );
+
+/** @ } */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif	/* _TINY_JSON_H_ */


### PR DESCRIPTION
This PR introduces a new subcommand with the ability to fetch password history from the API. This closes #245.

## Discussion points:
As far as I know, it is not possible to retrieve the history from the cache, so a call is needed for every password history retrieval. Adding this as an option to `show` or `ls` seemed like it would produce a lot of unnecessary calls, which is why it was made into a new subcommand.

In order to parse the results from the API, a third-party library JSON parser was added ([tiny-json](https://github.com/rafagafe/tiny-json)). However, given that the current requirements only include JSON types of objects, arrays, and strings, there might be room for optimization.