### PR TITLE
LastPass CLI - The FF file was not deleted after logout

### DIFF
--- a/feature-flag.c
+++ b/feature-flag.c
@@ -55,3 +55,7 @@ void feature_flag_load(struct feature_flag *feature_flag, unsigned const char ke
         feature_flag->url_encryption_enabled = !strcmp(ff_url_encryption, "1");
     }
 }
+
+void feature_flag_cleanup() {
+    config_unlink("session_ff_url_encryption");
+}

--- a/feature-flag.h
+++ b/feature-flag.h
@@ -11,5 +11,6 @@ struct feature_flag {
 void feature_flag_load_xml_attr(struct feature_flag *feature_flag, xmlDoc *doc, xmlAttrPtr attr);
 void feature_flag_save(const struct feature_flag *feature_flag, unsigned const char key[KDF_HASH_LEN]);
 void feature_flag_load(struct feature_flag *feature_flag, unsigned const char key[KDF_HASH_LEN]);
+void feature_flag_cleanup();
 
 #endif

--- a/session.c
+++ b/session.c
@@ -114,7 +114,9 @@ void session_kill()
 	config_unlink("session_privatekey");
 	config_unlink("session_server");
 	config_unlink("plaintext_key");
-	config_unlink("session_ff_url_encryption");
+	
+	feature_flag_cleanup();
+
 	agent_kill();
 	upload_queue_kill();
 }

--- a/session.c
+++ b/session.c
@@ -114,6 +114,7 @@ void session_kill()
 	config_unlink("session_privatekey");
 	config_unlink("session_server");
 	config_unlink("plaintext_key");
+	config_unlink("session_ff_url_encryption");
 	agent_kill();
 	upload_queue_kill();
 }


### PR DESCRIPTION
In the CLI the default behaviour when we logout is that it deletes the files related to the user’s session. We noticed that the files related to the feature flags are not being deleted.

The file session_ff_url_encryption should be deleted after logout.