### PR TITLE
LastPass CLI - The FF file was not deleted after logout

### DIFF
--- a/feature-flag.c
+++ b/feature-flag.c
@@ -45,11 +45,11 @@ void feature_flag_load_xml_attr(struct feature_flag *feature_flag, xmlDoc *doc, 
 }
 
 void feature_flag_save(const struct feature_flag *feature_flag, unsigned const char key[KDF_HASH_LEN]) {
-    config_write_encrypted_string("session_ff_url_encryption", feature_flag->url_encryption_enabled ? "1" : "0", key);
+    config_write_encrypted_string(SESSION_FF_URL_ENCRYPTION, feature_flag->url_encryption_enabled ? "1" : "0", key);
 }
 
 void feature_flag_load(struct feature_flag *feature_flag, unsigned const char key[KDF_HASH_LEN]) {
-    char * ff_url_encryption = config_read_encrypted_string("session_ff_url_encryption", key);
+    char * ff_url_encryption = config_read_encrypted_string(SESSION_FF_URL_ENCRYPTION, key);
 
     if (ff_url_encryption != NULL) {
         feature_flag->url_encryption_enabled = !strcmp(ff_url_encryption, "1");
@@ -57,5 +57,5 @@ void feature_flag_load(struct feature_flag *feature_flag, unsigned const char ke
 }
 
 void feature_flag_cleanup() {
-    config_unlink("session_ff_url_encryption");
+    config_unlink(SESSION_FF_URL_ENCRYPTION);
 }

--- a/feature-flag.c
+++ b/feature-flag.c
@@ -38,6 +38,8 @@
 #include "config.h"
 #include <string.h>
 
+#define SESSION_FF_URL_ENCRYPTION "session_ff_url_encryption"
+
 void feature_flag_load_xml_attr(struct feature_flag *feature_flag, xmlDoc *doc, xmlAttrPtr attr) {
     if (!xmlStrcmp(attr->name, BAD_CAST "url_encryption")) {
         feature_flag->url_encryption_enabled = !strcmp((char *)xmlNodeListGetString(doc, attr->children, 1), "1");

--- a/feature-flag.c
+++ b/feature-flag.c
@@ -55,3 +55,7 @@ void feature_flag_load(struct feature_flag *feature_flag, unsigned const char ke
         feature_flag->url_encryption_enabled = !strcmp(ff_url_encryption, "1");
     }
 }
+
+void feature_flag_cleanup() {
+    config_unlink("session_ff_url_encryption");
+}

--- a/feature-flag.h
+++ b/feature-flag.h
@@ -1,6 +1,8 @@
 #ifndef FEATUREFLAG_H
 #define FEATUREFLAG_H
 
+#define SESSION_FF_URL_ENCRYPTION "session_ff_url_encryption"
+
 #include <libxml/tree.h>
 #include <stdbool.h>
 

--- a/feature-flag.h
+++ b/feature-flag.h
@@ -1,10 +1,10 @@
 #ifndef FEATUREFLAG_H
 #define FEATUREFLAG_H
 
-#define SESSION_FF_URL_ENCRYPTION "session_ff_url_encryption"
-
 #include <libxml/tree.h>
 #include <stdbool.h>
+
+#define SESSION_FF_URL_ENCRYPTION "session_ff_url_encryption"
 
 struct feature_flag {
 	bool url_encryption_enabled;

--- a/feature-flag.h
+++ b/feature-flag.h
@@ -4,8 +4,6 @@
 #include <libxml/tree.h>
 #include <stdbool.h>
 
-#define SESSION_FF_URL_ENCRYPTION "session_ff_url_encryption"
-
 struct feature_flag {
 	bool url_encryption_enabled;
 };

--- a/feature-flag.h
+++ b/feature-flag.h
@@ -11,5 +11,6 @@ struct feature_flag {
 void feature_flag_load_xml_attr(struct feature_flag *feature_flag, xmlDoc *doc, xmlAttrPtr attr);
 void feature_flag_save(const struct feature_flag *feature_flag, unsigned const char key[KDF_HASH_LEN]);
 void feature_flag_load(struct feature_flag *feature_flag, unsigned const char key[KDF_HASH_LEN]);
+void feature_flag_cleanup();
 
 #endif

--- a/session.c
+++ b/session.c
@@ -114,7 +114,9 @@ void session_kill()
 	config_unlink("session_privatekey");
 	config_unlink("session_server");
 	config_unlink("plaintext_key");
-	config_unlink("session_ff_url_encryption");
+	
+	feature_flag_cleanup();
+
 	agent_kill();
 	upload_queue_kill();
 }

--- a/session.c
+++ b/session.c
@@ -114,6 +114,7 @@ void session_kill()
 	config_unlink("session_privatekey");
 	config_unlink("session_server");
 	config_unlink("plaintext_key");
+	config_unlink("session_ff_url_encryption");
 	agent_kill();
 	upload_queue_kill();
 }

--- a/xml.c
+++ b/xml.c
@@ -120,6 +120,8 @@ unsigned long long xml_login_check(const char *buf, struct session *session)
 				versionstr = (char *)xmlNodeListGetString(doc, attr->children, 1);
 				version = strtoull(versionstr, NULL, 10);
 			}
+
+			feature_flag_load_xml_attr(&session->feature_flag, doc, attr);
 		}
 	}
 out:


### PR DESCRIPTION
In the CLI the default behaviour when we logout is that it deletes the files related to the user’s session. We noticed that the files related to the feature flags are not being deleted.

The file session_ff_url_encryption should be deleted after logout.