### PR TITLE
Fix password change command not working

### DIFF
--- a/cmd-passwd.c
+++ b/cmd-passwd.c
@@ -235,7 +235,7 @@ int cmd_passwd(int argc, char **argv)
 
 	_cleanup_free_ char *enc_username = encrypt_and_base64(username, new_key);
 	ret = lastpass_pwchange_complete(session, username, enc_username,
-					 new_hex, iterations, &info);
+					 new_hex, hex, iterations, &info);
 
 	if (ret)
 		die("Password change failed.");

--- a/cmd-passwd.c
+++ b/cmd-passwd.c
@@ -235,7 +235,7 @@ int cmd_passwd(int argc, char **argv)
 
 	_cleanup_free_ char *enc_username = encrypt_and_base64(username, new_key);
 	ret = lastpass_pwchange_complete(session, username, enc_username,
-					 new_hex, hex, iterations, &info);
+					 hex, new_hex, iterations, &info);
 
 	if (ret)
 		die("Password change failed.");

--- a/endpoints.c
+++ b/endpoints.c
@@ -314,8 +314,8 @@ int lastpass_pwchange_start(const struct session *session, const char *username,
 int lastpass_pwchange_complete(const struct session *session,
 			       const char *username,
 			       const char *enc_username,
-			       const char new_hash[KDF_HEX_LEN],
 				   const char old_hash[KDF_HEX_LEN],
+			       const char new_hash[KDF_HEX_LEN],
 			       int new_iterations,
 			       struct pwchange_info *info)
 {

--- a/endpoints.c
+++ b/endpoints.c
@@ -315,6 +315,7 @@ int lastpass_pwchange_complete(const struct session *session,
 			       const char *username,
 			       const char *enc_username,
 			       const char new_hash[KDF_HEX_LEN],
+				   const char old_hash[KDF_HEX_LEN],
 			       int new_iterations,
 			       struct pwchange_info *info)
 {
@@ -365,6 +366,7 @@ int lastpass_pwchange_complete(const struct session *session,
 		"key_iterations", iterations_str,
 		"encrypted_username", enc_username,
 		"origusername", username,
+		"wxhash", old_hash,
 		NULL);
 
 	su_key_ind = 0;

--- a/endpoints.h
+++ b/endpoints.h
@@ -25,7 +25,7 @@ int lastpass_share_delete(const struct session *session, struct share *share);
 int lastpass_share_get_limits(const struct session *session, struct share *share, struct share_user *user, struct share_limit *ret_limit);
 int lastpass_share_set_limits(const struct session *session, struct share *share, struct share_user *user, struct share_limit *limit);
 int lastpass_pwchange_start(const struct session *session, const char *username, const char hash[KDF_HEX_LEN], struct pwchange_info *pwchange_info);
-int lastpass_pwchange_complete(const struct session *session, const char *username, const char *enc_username, const char new_hash[KDF_HEX_LEN], const char old_hash[KDF_HEX_LEN], int new_iterations, struct pwchange_info *pwchange_info);
+int lastpass_pwchange_complete(const struct session *session, const char *username, const char *enc_username, const char old_hash[KDF_HEX_LEN], const char new_hash[KDF_HEX_LEN], int new_iterations, struct pwchange_info *pwchange_info);
 int lastpass_upload(const struct session *session, struct list_head *accounts);
 int lastpass_load_attachment(const struct session *session, const char *shareid, struct attach *attach, char **result);
 #endif

--- a/endpoints.h
+++ b/endpoints.h
@@ -25,7 +25,7 @@ int lastpass_share_delete(const struct session *session, struct share *share);
 int lastpass_share_get_limits(const struct session *session, struct share *share, struct share_user *user, struct share_limit *ret_limit);
 int lastpass_share_set_limits(const struct session *session, struct share *share, struct share_user *user, struct share_limit *limit);
 int lastpass_pwchange_start(const struct session *session, const char *username, const char hash[KDF_HEX_LEN], struct pwchange_info *pwchange_info);
-int lastpass_pwchange_complete(const struct session *session, const char *username, const char *enc_username, const char new_hash[KDF_HEX_LEN], int new_iterations, struct pwchange_info *pwchange_info);
+int lastpass_pwchange_complete(const struct session *session, const char *username, const char *enc_username, const char new_hash[KDF_HEX_LEN], const char old_hash[KDF_HEX_LEN], int new_iterations, struct pwchange_info *pwchange_info);
 int lastpass_upload(const struct session *session, struct list_head *accounts);
 int lastpass_load_attachment(const struct session *session, const char *shareid, struct attach *attach, char **result);
 #endif


### PR DESCRIPTION
The last call to `lastpass/api.php` expected a new parameter `wxhash` with the hash of the old password. This PR adds this expected parameter to be able to successfully change the master password of the vault.