### PR TITLE
Replaced logic of reusing key as an IV

### DIFF
--- a/cipher.c
+++ b/cipher.c
@@ -478,7 +478,7 @@ char *cipher_encrypt_private_key(struct private_key *private_key,
 	unsigned char *key_ptext;
 	unsigned char *ctext = NULL;
 	char *key_hex_dst;
-	char *ctext_hex = NULL;
+	char *encrypted_base64 = NULL;
 	size_t len, ctext_len, hex_len;
 
 	if (!private_key->len)
@@ -495,12 +495,13 @@ char *cipher_encrypt_private_key(struct private_key *private_key,
 
 	memcpy(key_ptext + strlen(LP_PKEY_PREFIX) + hex_len,
 	       LP_PKEY_SUFFIX, strlen(LP_PKEY_SUFFIX));
+	
+	ctext_len = cipher_aes_encrypt(key_ptext, key, &ctext);
 
-	ctext_len = cipher_aes_encrypt_bytes(key_ptext, len, key, key, &ctext);
-	bytes_to_hex(ctext, &ctext_hex, ctext_len);
+	encrypted_base64 = cipher_base64(ctext, ctext_len);
 
 	free(ctext);
-	return ctext_hex;
+	return encrypted_base64;
 }
 
 /*

--- a/cipher.c
+++ b/cipher.c
@@ -501,6 +501,8 @@ char *cipher_encrypt_private_key(struct private_key *private_key,
 	encrypted_base64 = cipher_base64(ctext, ctext_len);
 
 	free(ctext);
+	free(key_ptext);
+
 	return encrypted_base64;
 }
 

--- a/cipher.c
+++ b/cipher.c
@@ -470,7 +470,7 @@ void cipher_decrypt_private_key(const char *key_hex,
 }
 
 /*
- * Encrypt RSA sharing key.  Encrypted key is returned as a hex-encoded string.
+ * Encrypt RSA sharing key.  Encrypted key is returned as a base64 string.
  */
 char *cipher_encrypt_private_key(struct private_key *private_key,
 				 unsigned const char key[KDF_HASH_LEN])


### PR DESCRIPTION
Before this change, the call to `aes_encrypt_bytes `was reusing the key as an IV for the encryption process. To fix this, the call to `aes_encrypt_bytes `was substituted with a call to `aes_encrypt `which internally generates a pseudo-random IV based on OpenSSL `RAND_bytes`.

Also fixed a memory leak due to `xcalloc`.