### PR TITLE
Improve attachment exporting, including making names file-system-safe

### DIFF
--- a/contrib/lpass-att-export.sh
+++ b/contrib/lpass-att-export.sh
@@ -33,6 +33,14 @@ fi
 
 command -v lpass >/dev/null 2>&1 || { echo >&2 "I require lpass but it's not installed.  Aborting."; exit 1; }
 
+# shellcheck disable=SC2034   # ignore unused version variables
+IFS='.' read -r lpass_ver_major lpass_ver_minor lpass_ver_patch lpass_ver_vcs <<< "$(lpass --version | sed 's/LastPass CLI v//')"
+if [ "${lpass_ver_major}" -gt 1 ] || [ "${lpass_ver_major}" -eq 1 ] && [ "${lpass_ver_minor}" -gt 6 ]; then
+  path_format="%/_as%/_ag%_an"
+else
+  path_format="%/as%/ag%an"
+fi
+
 if [ ! -d "${outdir}" ]; then
   echo "${outdir} does not exist. Exiting."
   exit 1
@@ -57,7 +65,7 @@ fi
 for id in ${ids}; do
   show=$(lpass show "${id}")
   attcount=$(echo "${show}" | grep -c "att-")
-  path=$(lpass show --format="%/as%/ag%an" "${id}" | uniq | tail -1)
+  path=$(lpass show --format="${path_format}" "${id}" | uniq | tail -1)
 
   until [ "${attcount}" -lt 1 ]; do
     # switch to read because the original way truncated filenames containing spaces

--- a/contrib/lpass-att-export.sh
+++ b/contrib/lpass-att-export.sh
@@ -33,34 +33,34 @@ fi
 
 command -v lpass >/dev/null 2>&1 || { echo >&2 "I require lpass but it's not installed.  Aborting."; exit 1; }
 
-if [ ! -d ${outdir} ]; then
+if [ ! -d "${outdir}" ]; then
   echo "${outdir} does not exist. Exiting."
   exit 1
 fi
 
 if ! lpass status; then
-  if [ -z ${email} ]; then
+  if [ -z "${email}" ]; then
     echo "No login data found, Please login with -l or use lpass login before."
     exit 1;
   fi
-  lpass login ${email}
+  lpass login "${email}"
 fi
 
-if [ -z ${id} ]; then
+if [ -z "${id}" ]; then
   ids=$(lpass ls | sed -n "s/^.*id:[[:space:]]*\([0-9]*\).*$/\1/p")
 else
   ids=${id}
 fi
 
 for id in ${ids}; do
-  show=$(lpass show ${id})
+  show=$(lpass show "${id}")
   attcount=$(echo "${show}" | grep -c "att-")
-  path=$(lpass show --format="%/as%/ag%an" ${id} | uniq | tail -1)
+  path=$(lpass show --format="%/as%/ag%an" "${id}" | uniq | tail -1)
 
-  until [  ${attcount} -lt 1 ]; do
-    att=`lpass show ${id} | grep att- | sed "${attcount}q;d" | tr -d :`
-    attid=$(echo ${att} | awk '{print $1}')
-    attname=$(echo ${att} | awk '{print $2}')
+  until [ "${attcount}" -lt 1 ]; do
+    att=$(lpass show "${id}" | grep att- | sed "${attcount}q;d" | tr -d :)
+    attid=$(echo "${att}" | awk '{print $1}')
+    attname=$(echo "${att}" | awk '{print $2}')
 
     if [[ -z  ${attname}  ]]; then
       attname=${path#*/}
@@ -74,11 +74,11 @@ for id in ${ids}; do
         out=${outdir}/${path}/${attcount}_${attname}
     fi
 
-    echo ${id} - ${path} ": " ${attid} "-" ${attname} " > " ${out}
+    echo "${id} - ${path} :  ${attid} - ${attname}  >  ${out}"
 
-    lpass show --attach=${attid} ${id} --quiet > "${out}"
+    lpass show "--attach=${attid}" "${id}" --quiet > "${out}"
 
-    let attcount-=1
+    (( attcount-=1 )) || true
   done
 done
 

--- a/contrib/lpass-att-export.sh
+++ b/contrib/lpass-att-export.sh
@@ -47,7 +47,9 @@ if ! lpass status; then
 fi
 
 if [ -z "${id}" ]; then
-  ids=$(lpass ls | sed -n "s/^.*id:[[:space:]]*\([0-9]*\).*$/\1/p")
+  # Get the ids of items that might have an attachment
+  # remove trailing carriage return if it's there
+  ids=$(lpass export --fields=id,attachpresent | grep ',1' | sed 's/,1\r\{0,1\}//')
 else
   ids=${id}
 fi

--- a/contrib/lpass-att-export.sh
+++ b/contrib/lpass-att-export.sh
@@ -47,7 +47,7 @@ if ! lpass status; then
 fi
 
 if [ -z ${id} ]; then
-  ids=$(lpass ls | sed -n "s/^.*id:\s*\([0-9]*\).*$/\1/p")
+  ids=$(lpass ls | sed -n "s/^.*id:[[:space:]]*\([0-9]*\).*$/\1/p")
 else
   ids=${id}
 fi

--- a/contrib/lpass-att-export.sh
+++ b/contrib/lpass-att-export.sh
@@ -60,9 +60,8 @@ for id in ${ids}; do
   path=$(lpass show --format="%/as%/ag%an" "${id}" | uniq | tail -1)
 
   until [ "${attcount}" -lt 1 ]; do
-    att=$(lpass show "${id}" | grep att- | sed "${attcount}q;d" | tr -d :)
-    attid=$(echo "${att}" | awk '{print $1}')
-    attname=$(echo "${att}" | awk '{print $2}')
+    # switch to read because the original way truncated filenames containing spaces
+    read -r attid attname <<< "$(lpass show "${id}" | grep att- | sed "${attcount}q;d" | tr -d :)"
 
     if [[ -z  ${attname}  ]]; then
       attname=${path#*/}

--- a/lpass.1.txt
+++ b/lpass.1.txt
@@ -171,7 +171,11 @@ the following placeholders:
 A slash can be added between the '%' and the placeholder to indicate that a
 slash should be appended, only if the printed value is expanded to a non-empty
 string.  For example, this command will properly show the full path to
-an account: `lpass ls --format="%/as%/ag%an"`.
+an account: `lpass ls --format="%/as%/ag%an"`. In the same way, an underscore may
+be added between the '%' and the placeholder to indicate that the value should
+be made file-system-safe by replacing forward slashes, tabs, carriage returns,
+and new lines with an underscore. This may be combined with the slash. For 
+example: `lpass show --format="%/_as%/_ag%_an"`.
 
 Modifying
 ~~~~~~~~~


### PR DESCRIPTION
## Summary

This PR includes several fixes and improvements for exporting attachments. This includes:

- Ensuring that exported attachment paths include only file-system-safe characters, preventing mysterious error messages and failures to export
- Correcting a bug in lpass-att-export.sh that caused attachment file names from being truncated when they contain a space.
- Changing a character class string to be POSIX compliant, enabling lpass-att-export.sh to be used with MacOS' default sed.
- Improving the speed of exporting attachments by lpass-att-export.sh, especially when a vault includes items with master password reprompt enabled
- Resolving shellcheck warnings in lpass-att-export.sh. This was mostly just implementing shell best practices, but does resolve one bug also.

## Details

#### File-System-Safety

Share and Group names are arbitrary strings and could contain characters that are not valid on file systems such as forward slashes ('/') and theoretically things like control characters. This applies to attachment file names also, though less commonly so since they usually will have a name from the uploading user's file system.

Thus, when exporting attachments, these strings must be sanitized. This is painful to do in lpass-att-export.sh, so this PR introduces the new '_' format string modifier. This modifier works similarly to the existing '/' modifier, but causes instances of forward slashes, carriage returns, new lines, and tabs with an underscore in output.

lpass-att-export.sh has been modified to use this new format string when a new-enough version of lpass is present.

- [ ] **I guessed that this PR will be released in a new v1.7.0 release. Please adjust version number parsing in lpass-att-export.sh if a different release number is selected.**

#### Truncated Attachment Names

lpass-att-export.sh used awk to read space separated tokens from the attachment description printed by lpass. This works fine for the attachment id, but incorrectly truncates file names containing spaces. Using the bash built-in `read` not only solves this but also prevents needing 2 external program calls and a temp variable.

#### POSIX compliant sed

The version of sed that currently ships with MacOS is old and only supports POSIX regular expressions. Thus, it supports the `[:space:]` character class but not the shorthand `/s` escape-like character class. So we switch to the long version and everyone is happy.

#### Export Speed

lpass-att-export.sh used `lpass ls` to iterate through every item in the vault, calling `lpass show` for each in order to find any that contain attachments. This will prompt for your master password for every item with a reprompt set, whether they have an attachment or not. It also is a lot of calls to PBKDF2 and if your interation count is high enough, the computation time can add up.

Instead we now use `lpass export` to find the ids of items that contain attachments via the id and attachpresent fields. This doesn't reprompt for every item. Much faster and less annoying!

#### Shellcheck Warnings

Most of the changes here were just to add quotes to ensure that variables don't get parsed wrong, and in most cases this doesn't actually change anything. But the script currently sometimes exits with a failure exit code even when it works fine due to the `let attcount-=1` at the very end. Switching to `(( attcount-=1 )) || true` prevents this. Not that it's a really big deal, but might as well fix it.